### PR TITLE
feat: support img_prefix for image file path in image data csv files

### DIFF
--- a/modelscope/models/cv/image_classification/utils.py
+++ b/modelscope/models/cv/image_classification/utils.py
@@ -73,12 +73,12 @@ def get_classes(classes=None):
 
 class MmDataset(BaseDataset):
 
-    def __init__(self, ms_dataset, pipeline, classes=None, test_mode=False):
+    def __init__(self, ms_dataset, pipeline, classes=None, test_mode=False, data_prefix=''):
         self.ms_dataset = ms_dataset
         if len(self.ms_dataset) < 1:
             raise ValueError('Dataset Error: dataset is empty')
         super(MmDataset, self).__init__(
-            data_prefix='',
+            data_prefix=data_prefix,
             pipeline=pipeline,
             classes=classes,
             test_mode=test_mode)

--- a/modelscope/trainers/cv/image_classifition_trainer.py
+++ b/modelscope/trainers/cv/image_classifition_trainer.py
@@ -353,7 +353,7 @@ class ImageClassifitionTrainer(BaseTrainer):
             classes = self.cfg.dataset.classes
 
         # set img_prefix for image data path in csv files.
-        if self.cfg.dataset.get("data_prefix", None) is None:
+        if self.cfg.dataset.get('data_prefix', None) is None:
             data_prefix = ''
         else:
             data_prefix = self.cfg.dataset.data_prefix

--- a/modelscope/trainers/cv/image_classifition_trainer.py
+++ b/modelscope/trainers/cv/image_classifition_trainer.py
@@ -434,7 +434,7 @@ class ImageClassifitionTrainer(BaseTrainer):
             classname_path = osp.join(data_root, 'classname.txt')
             classes = classname_path if osp.exists(classname_path) else None
         else:
-            classes = cfg.dataset.classes
+            classes = self.cfg.dataset.classes
         dataset = MmDataset(
             self.eval_dataset,
             pipeline=preprocess_transform(self.cfg.preprocessor.val),

--- a/modelscope/trainers/cv/image_classifition_trainer.py
+++ b/modelscope/trainers/cv/image_classifition_trainer.py
@@ -435,10 +435,18 @@ class ImageClassifitionTrainer(BaseTrainer):
             classes = classname_path if osp.exists(classname_path) else None
         else:
             classes = self.cfg.dataset.classes
+
+        # set img_prefix for image data path in csv files.
+        if self.cfg.dataset.get('data_prefix', None) is None:
+            data_prefix = ''
+        else:
+            data_prefix = self.cfg.dataset.data_prefix
+
         dataset = MmDataset(
             self.eval_dataset,
             pipeline=preprocess_transform(self.cfg.preprocessor.val),
-            classes=classes)
+            classes=classes,
+            data_prefix=data_prefix)
         # the extra round_up data will be removed during gpu/cpu collect
         data_loader = build_dataloader(
             dataset,

--- a/modelscope/trainers/cv/image_classifition_trainer.py
+++ b/modelscope/trainers/cv/image_classifition_trainer.py
@@ -352,11 +352,18 @@ class ImageClassifitionTrainer(BaseTrainer):
         else:
             classes = self.cfg.dataset.classes
 
+        # set img_prefix for image data path in csv files.
+        if self.cfg.dataset.data_prefix is None:
+            data_prefix = "",
+        else:
+            data_prefix = self.cfg.dataset.data_prefix      
+
         datasets = [
             MmDataset(
                 self.train_dataset,
                 pipeline=self.cfg.preprocessor.train,
-                classes=classes)
+                classes=classes,
+                data_prefix=data_prefix)
         ]
 
         if len(self.cfg.train.workflow) == 2:
@@ -366,7 +373,10 @@ class ImageClassifitionTrainer(BaseTrainer):
                 )
             val_data_pipeline = self.cfg.preprocessor.train
             val_dataset = MmDataset(
-                self.eval_dataset, pipeline=val_data_pipeline, classes=classes)
+                self.eval_dataset,
+                pipeline=val_data_pipeline,
+                classes=classes,
+                data_prefix=data_prefix)
             datasets.append(val_dataset)
 
         # save mmcls version, config file content and class names in
@@ -382,7 +392,8 @@ class ImageClassifitionTrainer(BaseTrainer):
             val_dataset = MmDataset(
                 self.eval_dataset,
                 pipeline=preprocess_transform(self.cfg.preprocessor.val),
-                classes=classes)
+                classes=classes,
+                data_prefix=data_prefix)
 
         # add an attribute for visualization convenience
         train_model(

--- a/modelscope/trainers/cv/image_classifition_trainer.py
+++ b/modelscope/trainers/cv/image_classifition_trainer.py
@@ -353,10 +353,10 @@ class ImageClassifitionTrainer(BaseTrainer):
             classes = self.cfg.dataset.classes
 
         # set img_prefix for image data path in csv files.
-        if self.cfg.dataset.data_prefix is None:
-            data_prefix = "",
+        if self.cfg.dataset.get("data_prefix", None) is None:
+            data_prefix = ''
         else:
-            data_prefix = self.cfg.dataset.data_prefix      
+            data_prefix = self.cfg.dataset.data_prefix
 
         datasets = [
             MmDataset(


### PR DESCRIPTION
When we tried to load image files from local disk, for example:

we downloaded Mini ImageNet data: https://modelscope.cn/datasets/tany0699/mini_imagenet100/summary
we have "train.csv" which contains image file paths:
![image](https://user-images.githubusercontent.com/121550081/209832323-9393f738-a2b6-41a4-a5c3-90b1a72d5850.png)

and we also have "train.zip" which contains images files

then we try to load local image data:
![image](https://user-images.githubusercontent.com/121550081/209832833-01fc523a-5eb6-4c77-9967-d39182db6cd5.png)

but since the paths in "train.csv" using such format: "train/{category}/{imagefile}.jpg", trainer can't find the true path of a image file:
![image](https://user-images.githubusercontent.com/121550081/209833827-7b3f43fb-cd82-4356-b78b-855e936fb8c4.png)

this PR is trying to support this feature.
