### PR TITLE
Correct DDIM sampling on GPU

### DIFF
--- a/modelscope/models/multi_modal/diffusion/diffusion.py
+++ b/modelscope/models/multi_modal/diffusion/diffusion.py
@@ -40,6 +40,7 @@ def discretized_gaussian_log_likelihood(x0, mean, log_scale):
 
 
 def _i(tensor, t, x):
+    tensor = tensor.to(x.device)
     shape = (x.size(0), ) + (1, ) * (x.ndim - 1)
     return tensor[t].view(shape).to(x)
 


### PR DESCRIPTION
If one currently runs the following code snippet:

```py
import cv2
from modelscope.pipelines import pipeline
from modelscope.utils.constant import Tasks

text2image = pipeline(Tasks.text_to_image_synthesis, 'damo/cv_diffusion_text-to-image-synthesis_tiny')
result = text2image({'text': '中国山水画', "solver": ddim})

cv2.imwrite('result.png', result['output_imgs'][0])
```

A cuda device mismatch occurs. This PR fixes that.