### PR TITLE
Fix device mismatch

### DIFF
--- a/modelscope/models/multi_modal/video_synthesis/diffusion.py
+++ b/modelscope/models/multi_modal/video_synthesis/diffusion.py
@@ -10,6 +10,7 @@ __all__ = ['GaussianDiffusion', 'beta_schedule']
 def _i(tensor, t, x):
     r"""Index tensor using t and format the output according to x.
     """
+    tensor = tensor.to(x.device)
     shape = (x.size(0), ) + (1, ) * (x.ndim - 1)
     return tensor[t].view(shape).to(x)
 


### PR DESCRIPTION
I think the same fix as #173 should be applied to `video_synthesis/diffusion.py`.

> A cuda device mismatch occurs. This PR fixes that.