### PR TITLE
Set default topk when num_classes < 5

### DIFF
--- a/modelscope/trainers/cv/image_classifition_trainer.py
+++ b/modelscope/trainers/cv/image_classifition_trainer.py
@@ -502,7 +502,7 @@ class ImageClassifitionTrainer(BaseTrainer):
             # will cause error when number of classes less then 5.
             # set topk as (1,) if len(CLASSES) < 5:
             elif len(CLASSES) < 5:
-                metric_options['topk'] = (1,)
+                metric_options['topk'] = (1, )
             if self.cfg.evaluation.metrics:
                 eval_results = dataset.evaluate(
                     results=outputs,

--- a/modelscope/trainers/cv/image_classifition_trainer.py
+++ b/modelscope/trainers/cv/image_classifition_trainer.py
@@ -498,6 +498,8 @@ class ImageClassifitionTrainer(BaseTrainer):
             metric_options = self.cfg.evaluation.get('metric_options', {})
             if 'topk' in metric_options.keys():
                 metric_options['topk'] = tuple(metric_options['topk'])
+            elif len(CLASSES) < 6:
+                metric_options['topk'] = (1,)
             if self.cfg.evaluation.metrics:
                 eval_results = dataset.evaluate(
                     results=outputs,

--- a/modelscope/trainers/cv/image_classifition_trainer.py
+++ b/modelscope/trainers/cv/image_classifition_trainer.py
@@ -498,7 +498,10 @@ class ImageClassifitionTrainer(BaseTrainer):
             metric_options = self.cfg.evaluation.get('metric_options', {})
             if 'topk' in metric_options.keys():
                 metric_options['topk'] = tuple(metric_options['topk'])
-            elif len(CLASSES) < 6:
+            # mmcls will set the default value of topk to (1, 5) which
+            # will cause error when number of classes less then 5.
+            # set topk as (1,) if len(CLASSES) < 5:
+            elif len(CLASSES) < 5:
                 metric_options['topk'] = (1,)
             if self.cfg.evaluation.metrics:
                 eval_results = dataset.evaluate(


### PR DESCRIPTION
mmcls的BaseDataset.evaluate()在不设置 topk的情况下会将topk默认设置为(1, 5)：
https://github.com/open-mmlab/mmpretrain/blob/master/mmcls/datasets/base_dataset.py#L170

如果train/val数据的种类数小于5，并且在cfg中未设置topk，代码运行将会报错：
```
  File "/opt/conda/lib/python3.7/site-packages/modelscope/trainers/cv/image_classifition_trainer.py", line 506, in evaluate
    logger=logger)
  File "/opt/conda/lib/python3.7/site-packages/mmcls/datasets/base_dataset.py", line 178, in evaluate
    acc = accuracy(results, gt_labels, topk=topk)
  File "/opt/conda/lib/python3.7/site-packages/mmcls/models/losses/accuracy.py", line 116, in accuracy
    res = accuracy_torch(pred, target, topk, thrs)
  File "/opt/conda/lib/python3.7/site-packages/mmcls/models/losses/accuracy.py", line 60, in accuracy_torch
    pred_score, pred_label = pred.topk(maxk, dim=1)
RuntimeError: selected index k out of range
```
因此在class种类小于5的情况下，将topk默认值设置成(1,)