### PR TITLE
修复 fid_dialogue_pipeline.py 在cpu下推理时的异常

### DIFF
--- a/modelscope/pipelines/nlp/fid_dialogue_pipeline.py
+++ b/modelscope/pipelines/nlp/fid_dialogue_pipeline.py
@@ -191,8 +191,8 @@ class FidDialoguePipeline(Pipeline):
     def postprocess(self, inputs: TokenGeneratorOutput,
                     **postprocess_params) -> Dict[str, Any]:
 
-        if torch.cuda.is_available():
-            hypotheses = inputs.sequences.detach().cpu().tolist()
+        # if torch.cuda.is_available():
+        hypotheses = inputs.sequences.detach().cpu().tolist()
 
         response = self.preprocessor_tokenizer.decode(
             hypotheses[0], skip_special_tokens=self.is_t5)


### PR DESCRIPTION
修复在cpu下推理时的错误，这里不应该检查cuda是否可用。这里的逻辑似乎有错误

```
│ /Users/xxxx/.pyenv/versions/3.10.0/lib/python3.10/site-packages/modelscope/pipelines/nlp/fid_di │
│ alogue_pipeline.py:198 in postprocess                                                            │
│                                                                                                  │
│   195 │   │   │   hypotheses = inputs.sequences.detach().cpu().tolist()                          │
│   196 │   │                                                                                      │
│   197 │   │   response = self.preprocessor_tokenizer.decode(                                     │
│ ❱ 198 │   │   │   hypotheses[0], skip_special_tokens=self.is_t5)                                 │
│   199 │   │                                                                                      │
│   200 │   │   token_mapping = {                                                                  │
│   201 │   │   │   '<extra_id_22>': '\n',                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
UnboundLocalError: local variable 'hypotheses' referenced before assignment
```