### PR TITLE
Stable Diffusion model checkpoint export to onnx.

### DIFF
--- a/modelscope/exporters/__init__.py
+++ b/modelscope/exporters/__init__.py
@@ -13,11 +13,13 @@ if TYPE_CHECKING:
     from .nlp import SbertForSequenceClassificationExporter, SbertForZeroShotClassificationExporter
     from .torch_model_exporter import TorchModelExporter
     from .cv import FaceDetectionSCRFDExporter
+    from .multi_modal import StableDiffuisonExporter
 else:
     _import_structure = {
         'base': ['Exporter'],
         'builder': ['build_exporter'],
         'cv': ['CartoonTranslationExporter', 'FaceDetectionSCRFDExporter'],
+        'multi_modal': ['StableDiffuisonExporter'],
         'nlp': [
             'CsanmtForTranslationExporter',
             'SbertForSequenceClassificationExporter',

--- a/modelscope/exporters/multi_modal/__init__.py
+++ b/modelscope/exporters/multi_modal/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+from typing import TYPE_CHECKING
+
+from modelscope.utils.import_utils import LazyImportModule
+
+if TYPE_CHECKING:
+    from .stable_diffusion_export import StableDiffuisonExporter
+else:
+    _import_structure = {
+        'stable_diffusion_export': ['StableDiffuisonExporter'],
+    }
+
+    import sys
+
+    sys.modules[__name__] = LazyImportModule(
+        __name__,
+        globals()['__file__'],
+        _import_structure,
+        module_spec=__spec__,
+        extra_objects={},
+    )

--- a/modelscope/exporters/multi_modal/stable_diffusion_exporter.py
+++ b/modelscope/exporters/multi_modal/stable_diffusion_exporter.py
@@ -1,17 +1,18 @@
+from collections import OrderedDict
+from typing import Any, Dict, Mapping, Tuple
+
+from torch.utils.data.dataloader import default_collate
 import argparse
 import os
 import shutil
-from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Dict, Mapping, Tuple
 
 import onnx
 import torch
-from diffusers import (OnnxRuntimeModel, OnnxStableDiffusionPipeline,
-                       StableDiffusionPipeline)
 from packaging import version
 from torch.onnx import export
-from torch.utils.data.dataloader import default_collate
+
+from diffusers import OnnxRuntimeModel, OnnxStableDiffusionPipeline, StableDiffusionPipeline
 
 from modelscope.exporters.builder import EXPORTERS
 from modelscope.exporters.torch_model_exporter import TorchModelExporter
@@ -21,13 +22,11 @@ from modelscope.utils.constant import ModeKeys, Tasks
 from modelscope.utils.hub import snapshot_download
 
 
-@EXPORTERS.register_module(
-    Tasks.text_to_image_synthesis, module_name=Models.stable_diffusion)
+@EXPORTERS.register_module(Tasks.text_to_image_synthesis, module_name=Models.stable_diffusion)
 class StableDiffuisonExporter(TorchModelExporter):
 
     @torch.no_grad()
     def export_onnx(self,
-                    model_path: str,
                     output_path: str,
                     opset: int = 14,
                     fp16: bool = False):
@@ -39,88 +38,63 @@ class StableDiffuisonExporter(TorchModelExporter):
             opset: The version of the ONNX operator set to use.
             fp16: Whether to use float16.
         """
-        # Conversion weight accuracy.
-        dtype = torch.float16 if fp16 else torch.float32
-        if fp16 and torch.cuda.is_available():
-            device = 'cuda'
-        elif fp16 and not torch.cuda.is_available():
-            raise ValueError(
-                '`float16` model export is only supported on GPUs with CUDA')
-        else:
-            device = 'cpu'
-        # download and load models
-        if not os.path.isdir(model_path):
-            model_path = snapshot_download(model_path)
-        pipeline = StableDiffusionPipeline.from_pretrained(
-            model_path, torch_dtype=dtype).to(device)
         output_path = Path(output_path)
 
+        # Conversion weight accuracy and device.
+        dtype = torch.float16 if fp16 else torch.float32
+        if fp16 and torch.cuda.is_available():
+            device = "cuda"
+        elif fp16 and not torch.cuda.is_available():
+            raise ValueError("`float16` model export is only supported on GPUs with CUDA")
+        else:
+            device = "cpu"
+        self.model = self.model.to(device)
+
         # Text encoder
-        num_tokens = pipeline.text_encoder.config.max_position_embeddings
-        text_hidden_size = pipeline.text_encoder.config.hidden_size
-        text_input = pipeline.tokenizer(
-            'A sample prompt',
-            padding='max_length',
-            max_length=pipeline.tokenizer.model_max_length,
+        num_tokens = self.model.text_encoder.config.max_position_embeddings
+        text_hidden_size = self.model.text_encoder.config.hidden_size
+        text_input = self.model.tokenizer(
+            "A sample prompt",
+            padding="max_length",
+            max_length=self.model.tokenizer.model_max_length,
             truncation=True,
-            return_tensors='pt',
+            return_tensors="pt",
         )
         self.export_help(
-            pipeline.text_encoder,
-            model_args=(text_input.input_ids.to(
-                device=device, dtype=torch.int32)),
-            output_path=output_path / 'text_encoder' / 'model.onnx',
-            ordered_input_names=['input_ids'],
-            output_names=['last_hidden_state', 'pooler_output'],
+            self.model.text_encoder,
+            model_args=(text_input.input_ids.to(device=device, dtype=torch.int32)),
+            output_path=output_path / "text_encoder" / "model.onnx",
+            ordered_input_names=["input_ids"],
+            output_names=["last_hidden_state", "pooler_output"],
             dynamic_axes={
-                'input_ids': {
-                    0: 'batch',
-                    1: 'sequence'
-                },
+                "input_ids": {0: "batch", 1: "sequence"},
             },
             opset=opset,
         )
-        del pipeline.text_encoder
+        del self.model.text_encoder
 
         # UNET
-        unet_in_channels = pipeline.unet.config.in_channels
-        unet_sample_size = pipeline.unet.config.sample_size
-        unet_path = output_path / 'unet' / 'model.onnx'
+        unet_in_channels = self.model.unet.config.in_channels
+        unet_sample_size = self.model.unet.config.sample_size
+        unet_path = output_path / "unet" / "model.onnx"
         self.export_help(
-            pipeline.unet,
+            self.model.unet,
             model_args=(
-                torch.randn(2, unet_in_channels, unet_sample_size,
-                            unet_sample_size).to(device=device, dtype=dtype),
+                torch.randn(2, unet_in_channels, unet_sample_size, unet_sample_size).to(device=device, dtype=dtype),
                 torch.randn(2).to(device=device, dtype=dtype),
-                torch.randn(2, num_tokens,
-                            text_hidden_size).to(device=device, dtype=dtype),
+                torch.randn(2, num_tokens, text_hidden_size).to(device=device, dtype=dtype),
                 False,
             ),
             output_path=unet_path,
-            ordered_input_names=[
-                'sample', 'timestep', 'encoder_hidden_states', 'return_dict'
-            ],
-            output_names=[
-                'out_sample'
-            ],  # has to be different from "sample" for correct tracing
+            ordered_input_names=["sample", "timestep", "encoder_hidden_states", "return_dict"],
+            output_names=["out_sample"],  # has to be different from "sample" for correct tracing
             dynamic_axes={
-                'sample': {
-                    0: 'batch',
-                    1: 'channels',
-                    2: 'height',
-                    3: 'width'
-                },
-                'timestep': {
-                    0: 'batch'
-                },
-                'encoder_hidden_states': {
-                    0: 'batch',
-                    1: 'sequence'
-                },
+                "sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+                "timestep": {0: "batch"},
+                "encoder_hidden_states": {0: "batch", 1: "sequence"},
             },
             opset=opset,
-            use_external_data_format=
-            True,  # UNet is > 2GB, so the weights need to be split
+            use_external_data_format=True,  # UNet is > 2GB, so the weights need to be split
         )
         unet_model_path = str(unet_path.absolute().as_posix())
         unet_dir = os.path.dirname(unet_model_path)
@@ -134,41 +108,34 @@ class StableDiffuisonExporter(TorchModelExporter):
             unet_model_path,
             save_as_external_data=True,
             all_tensors_to_one_file=True,
-            location='weights.pb',
+            location="weights.pb",
             convert_attribute=False,
         )
-        del pipeline.unet
+        del self.model.unet
 
         # VAE ENCODER
-        vae_encoder = pipeline.vae
+        vae_encoder = self.model.vae
         vae_in_channels = vae_encoder.config.in_channels
         vae_sample_size = vae_encoder.config.sample_size
         # need to get the raw tensor output (sample) from the encoder
-        vae_encoder.forward = lambda sample, return_dict: vae_encoder.encode(
-            sample, return_dict)[0].sample()
+        vae_encoder.forward = lambda sample, return_dict: vae_encoder.encode(sample, return_dict)[0].sample()
         self.export_help(
             vae_encoder,
             model_args=(
-                torch.randn(1, vae_in_channels, vae_sample_size,
-                            vae_sample_size).to(device=device, dtype=dtype),
+                torch.randn(1, vae_in_channels, vae_sample_size, vae_sample_size).to(device=device, dtype=dtype),
                 False,
             ),
-            output_path=output_path / 'vae_encoder' / 'model.onnx',
-            ordered_input_names=['sample', 'return_dict'],
-            output_names=['latent_sample'],
+            output_path=output_path / "vae_encoder" / "model.onnx",
+            ordered_input_names=["sample", "return_dict"],
+            output_names=["latent_sample"],
             dynamic_axes={
-                'sample': {
-                    0: 'batch',
-                    1: 'channels',
-                    2: 'height',
-                    3: 'width'
-                },
+                "sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
             },
             opset=opset,
         )
 
         # VAE DECODER
-        vae_decoder = pipeline.vae
+        vae_decoder = self.model.vae
         vae_latent_channels = vae_decoder.config.latent_channels
         vae_out_channels = vae_decoder.config.out_channels
         # forward only through the decoder part
@@ -176,33 +143,27 @@ class StableDiffuisonExporter(TorchModelExporter):
         self.export_help(
             vae_decoder,
             model_args=(
-                torch.randn(1, vae_latent_channels, unet_sample_size,
-                            unet_sample_size).to(device=device, dtype=dtype),
+                torch.randn(1, vae_latent_channels, unet_sample_size, unet_sample_size).to(device=device, dtype=dtype),
                 False,
             ),
-            output_path=output_path / 'vae_decoder' / 'model.onnx',
-            ordered_input_names=['latent_sample', 'return_dict'],
-            output_names=['sample'],
+            output_path=output_path / "vae_decoder" / "model.onnx",
+            ordered_input_names=["latent_sample", "return_dict"],
+            output_names=["sample"],
             dynamic_axes={
-                'latent_sample': {
-                    0: 'batch',
-                    1: 'channels',
-                    2: 'height',
-                    3: 'width'
-                },
+                "latent_sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
             },
             opset=opset,
         )
-        del pipeline.vae
+        del self.model.vae
 
         # SAFETY CHECKER
-        if pipeline.safety_checker is not None:
-            safety_checker = pipeline.safety_checker
+        if self.model.safety_checker is not None:
+            safety_checker = self.model.safety_checker
             clip_num_channels = safety_checker.config.vision_config.num_channels
             clip_image_size = safety_checker.config.vision_config.image_size
             safety_checker.forward = safety_checker.forward_onnx
             self.export_help(
-                pipeline.safety_checker,
+                self.model.safety_checker,
                 model_args=(
                     torch.randn(
                         1,
@@ -210,60 +171,43 @@ class StableDiffuisonExporter(TorchModelExporter):
                         clip_image_size,
                         clip_image_size,
                     ).to(device=device, dtype=dtype),
-                    torch.randn(1, vae_sample_size, vae_sample_size,
-                                vae_out_channels).to(
-                                    device=device, dtype=dtype),
+                    torch.randn(1, vae_sample_size, vae_sample_size, vae_out_channels).to(device=device, dtype=dtype),
                 ),
-                output_path=output_path / 'safety_checker' / 'model.onnx',
-                ordered_input_names=['clip_input', 'images'],
-                output_names=['out_images', 'has_nsfw_concepts'],
+                output_path=output_path / "safety_checker" / "model.onnx",
+                ordered_input_names=["clip_input", "images"],
+                output_names=["out_images", "has_nsfw_concepts"],
                 dynamic_axes={
-                    'clip_input': {
-                        0: 'batch',
-                        1: 'channels',
-                        2: 'height',
-                        3: 'width'
-                    },
-                    'images': {
-                        0: 'batch',
-                        1: 'height',
-                        2: 'width',
-                        3: 'channels'
-                    },
+                    "clip_input": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+                    "images": {0: "batch", 1: "height", 2: "width", 3: "channels"},
                 },
                 opset=opset,
             )
-            del pipeline.safety_checker
-            safety_checker = OnnxRuntimeModel.from_pretrained(
-                output_path / 'safety_checker')
-            feature_extractor = pipeline.feature_extractor
+            del self.model.safety_checker
+            safety_checker = OnnxRuntimeModel.from_pretrained(output_path / "safety_checker")
+            feature_extractor = self.model.feature_extractor
         else:
             safety_checker = None
             feature_extractor = None
 
         onnx_pipeline = OnnxStableDiffusionPipeline(
-            vae_encoder=OnnxRuntimeModel.from_pretrained(output_path
-                                                         / 'vae_encoder'),
-            vae_decoder=OnnxRuntimeModel.from_pretrained(output_path
-                                                         / 'vae_decoder'),
-            text_encoder=OnnxRuntimeModel.from_pretrained(output_path
-                                                          / 'text_encoder'),
-            tokenizer=pipeline.tokenizer,
-            unet=OnnxRuntimeModel.from_pretrained(output_path / 'unet'),
-            scheduler=pipeline.scheduler,
+            vae_encoder=OnnxRuntimeModel.from_pretrained(output_path / "vae_encoder"),
+            vae_decoder=OnnxRuntimeModel.from_pretrained(output_path / "vae_decoder"),
+            text_encoder=OnnxRuntimeModel.from_pretrained(output_path / "text_encoder"),
+            tokenizer=self.model.tokenizer,
+            unet=OnnxRuntimeModel.from_pretrained(output_path / "unet"),
+            scheduler=self.model.scheduler,
             safety_checker=safety_checker,
             feature_extractor=feature_extractor,
             requires_safety_checker=safety_checker is not None,
         )
 
         onnx_pipeline.save_pretrained(output_path)
-        print('ONNX pipeline saved to', output_path)
+        print("ONNX pipeline model saved to", output_path)
 
-        del pipeline
+        del self.model
         del onnx_pipeline
-        _ = OnnxStableDiffusionPipeline.from_pretrained(
-            output_path, provider='CPUExecutionProvider')
-        print('ONNX pipeline is loadable')
+        _ = OnnxStableDiffusionPipeline.from_pretrained(output_path, provider="CPUExecutionProvider")
+        print("ONNX pipeline model is loadable")
 
     def export_help(
         self,
@@ -278,9 +222,7 @@ class StableDiffuisonExporter(TorchModelExporter):
     ):
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        is_torch_less_than_1_11 = version.parse(
-            version.parse(
-                torch.__version__).base_version) < version.parse('1.11')
+        is_torch_less_than_1_11 = version.parse(version.parse(torch.__version__).base_version) < version.parse("1.11")
         if is_torch_less_than_1_11:
             export(
                 model,

--- a/modelscope/exporters/multi_modal/stable_diffusion_exporter.py
+++ b/modelscope/exporters/multi_modal/stable_diffusion_exporter.py
@@ -1,0 +1,256 @@
+from collections import OrderedDict
+from typing import Any, Dict, Mapping, Tuple
+
+from torch.utils.data.dataloader import default_collate
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+import onnx
+import torch
+from packaging import version
+from torch.onnx import export
+
+from diffusers import OnnxRuntimeModel, OnnxStableDiffusionPipeline, StableDiffusionPipeline
+
+from modelscope.exporters.builder import EXPORTERS
+from modelscope.exporters.torch_model_exporter import TorchModelExporter
+from modelscope.metainfo import Models
+from modelscope.preprocessors import Preprocessor
+from modelscope.utils.constant import ModeKeys, Tasks
+from modelscope.utils.hub import snapshot_download
+
+
+@EXPORTERS.register_module(Tasks.text_to_image_synthesis, module_name=Models.stable_diffusion)
+class StableDiffuisonExporter(TorchModelExporter):
+
+    @torch.no_grad()
+    def export_onnx(self, 
+                    model_path: str, 
+                    output_path: str, 
+                    opset: int = 14, 
+                    fp16: bool = False):
+        """Export the model as onnx format files.
+
+        Args:
+            model_path: The model id or local path.
+            output_dir: The output dir.
+            opset: The version of the ONNX operator set to use.
+            fp16: Whether to use float16.
+        """
+        
+        # Conversion weight accuracy.
+        dtype = torch.float16 if fp16 else torch.float32
+        if fp16 and torch.cuda.is_available():
+            device = "cuda"
+        elif fp16 and not torch.cuda.is_available():
+            raise ValueError("`float16` model export is only supported on GPUs with CUDA")
+        else:
+            device = "cpu"
+        
+        # download and load models
+        if not os.path.isdir(model_path):
+            model_path = snapshot_download(model_path)
+        pipeline = StableDiffusionPipeline.from_pretrained(model_path, torch_dtype=dtype).to(device)
+        output_path = Path(output_path)
+
+        # Text encoder
+        num_tokens = pipeline.text_encoder.config.max_position_embeddings
+        text_hidden_size = pipeline.text_encoder.config.hidden_size
+        text_input = pipeline.tokenizer(
+            "A sample prompt",
+            padding="max_length",
+            max_length=pipeline.tokenizer.model_max_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+        self.export_help(
+            pipeline.text_encoder,
+            # casting to torch.int32 until the CLIP fix is released: https://github.com/huggingface/transformers/pull/18515/files
+            model_args=(text_input.input_ids.to(device=device, dtype=torch.int32)),
+            output_path=output_path / "text_encoder" / "model.onnx",
+            ordered_input_names=["input_ids"],
+            output_names=["last_hidden_state", "pooler_output"],
+            dynamic_axes={
+                "input_ids": {0: "batch", 1: "sequence"},
+            },
+            opset=opset,
+        )
+        del pipeline.text_encoder
+
+        # UNET
+        unet_in_channels = pipeline.unet.config.in_channels
+        unet_sample_size = pipeline.unet.config.sample_size
+        unet_path = output_path / "unet" / "model.onnx"
+        self.export_help(
+            pipeline.unet,
+            model_args=(
+                torch.randn(2, unet_in_channels, unet_sample_size, unet_sample_size).to(device=device, dtype=dtype),
+                torch.randn(2).to(device=device, dtype=dtype),
+                torch.randn(2, num_tokens, text_hidden_size).to(device=device, dtype=dtype),
+                False,
+            ),
+            output_path=unet_path,
+            ordered_input_names=["sample", "timestep", "encoder_hidden_states", "return_dict"],
+            output_names=["out_sample"],  # has to be different from "sample" for correct tracing
+            dynamic_axes={
+                "sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+                "timestep": {0: "batch"},
+                "encoder_hidden_states": {0: "batch", 1: "sequence"},
+            },
+            opset=opset,
+            use_external_data_format=True,  # UNet is > 2GB, so the weights need to be split
+        )
+        unet_model_path = str(unet_path.absolute().as_posix())
+        unet_dir = os.path.dirname(unet_model_path)
+        unet = onnx.load(unet_model_path)
+        # clean up existing tensor files
+        shutil.rmtree(unet_dir)
+        os.mkdir(unet_dir)
+        # collate external tensor files into one
+        onnx.save_model(
+            unet,
+            unet_model_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="weights.pb",
+            convert_attribute=False,
+        )
+        del pipeline.unet
+
+        # VAE ENCODER
+        vae_encoder = pipeline.vae
+        vae_in_channels = vae_encoder.config.in_channels
+        vae_sample_size = vae_encoder.config.sample_size
+        # need to get the raw tensor output (sample) from the encoder
+        vae_encoder.forward = lambda sample, return_dict: vae_encoder.encode(sample, return_dict)[0].sample()
+        self.export_help(
+            vae_encoder,
+            model_args=(
+                torch.randn(1, vae_in_channels, vae_sample_size, vae_sample_size).to(device=device, dtype=dtype),
+                False,
+            ),
+            output_path=output_path / "vae_encoder" / "model.onnx",
+            ordered_input_names=["sample", "return_dict"],
+            output_names=["latent_sample"],
+            dynamic_axes={
+                "sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+            },
+            opset=opset,
+        )
+
+        # VAE DECODER
+        vae_decoder = pipeline.vae
+        vae_latent_channels = vae_decoder.config.latent_channels
+        vae_out_channels = vae_decoder.config.out_channels
+        # forward only through the decoder part
+        vae_decoder.forward = vae_encoder.decode
+        self.export_help(
+            vae_decoder,
+            model_args=(
+                torch.randn(1, vae_latent_channels, unet_sample_size, unet_sample_size).to(device=device, dtype=dtype),
+                False,
+            ),
+            output_path=output_path / "vae_decoder" / "model.onnx",
+            ordered_input_names=["latent_sample", "return_dict"],
+            output_names=["sample"],
+            dynamic_axes={
+                "latent_sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+            },
+            opset=opset,
+        )
+        del pipeline.vae
+
+        # SAFETY CHECKER
+        if pipeline.safety_checker is not None:
+            safety_checker = pipeline.safety_checker
+            clip_num_channels = safety_checker.config.vision_config.num_channels
+            clip_image_size = safety_checker.config.vision_config.image_size
+            safety_checker.forward = safety_checker.forward_onnx
+            self.export_help(
+                pipeline.safety_checker,
+                model_args=(
+                    torch.randn(
+                        1,
+                        clip_num_channels,
+                        clip_image_size,
+                        clip_image_size,
+                    ).to(device=device, dtype=dtype),
+                    torch.randn(1, vae_sample_size, vae_sample_size, vae_out_channels).to(device=device, dtype=dtype),
+                ),
+                output_path=output_path / "safety_checker" / "model.onnx",
+                ordered_input_names=["clip_input", "images"],
+                output_names=["out_images", "has_nsfw_concepts"],
+                dynamic_axes={
+                    "clip_input": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+                    "images": {0: "batch", 1: "height", 2: "width", 3: "channels"},
+                },
+                opset=opset,
+            )
+            del pipeline.safety_checker
+            safety_checker = OnnxRuntimeModel.from_pretrained(output_path / "safety_checker")
+            feature_extractor = pipeline.feature_extractor
+        else:
+            safety_checker = None
+            feature_extractor = None
+
+        onnx_pipeline = OnnxStableDiffusionPipeline(
+            vae_encoder=OnnxRuntimeModel.from_pretrained(output_path / "vae_encoder"),
+            vae_decoder=OnnxRuntimeModel.from_pretrained(output_path / "vae_decoder"),
+            text_encoder=OnnxRuntimeModel.from_pretrained(output_path / "text_encoder"),
+            tokenizer=pipeline.tokenizer,
+            unet=OnnxRuntimeModel.from_pretrained(output_path / "unet"),
+            scheduler=pipeline.scheduler,
+            safety_checker=safety_checker,
+            feature_extractor=feature_extractor,
+            requires_safety_checker=safety_checker is not None,
+        )
+
+        onnx_pipeline.save_pretrained(output_path)
+        print("ONNX pipeline saved to", output_path)
+
+        del pipeline
+        del onnx_pipeline
+        _ = OnnxStableDiffusionPipeline.from_pretrained(output_path, provider="CPUExecutionProvider")
+        print("ONNX pipeline is loadable")
+
+    def export_help(
+        self,
+        model,
+        model_args: tuple,
+        output_path: Path,
+        ordered_input_names,
+        output_names,
+        dynamic_axes,
+        opset,
+        use_external_data_format=False,
+    ):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        is_torch_less_than_1_11 = version.parse(version.parse(torch.__version__).base_version) < version.parse("1.11")
+        if is_torch_less_than_1_11:
+            export(
+                model,
+                model_args,
+                f=output_path.as_posix(),
+                input_names=ordered_input_names,
+                output_names=output_names,
+                dynamic_axes=dynamic_axes,
+                do_constant_folding=True,
+                use_external_data_format=use_external_data_format,
+                enable_onnx_checker=True,
+                opset_version=opset,
+            )
+        else:
+            export(
+                model,
+                model_args,
+                f=output_path.as_posix(),
+                input_names=ordered_input_names,
+                output_names=output_names,
+                dynamic_axes=dynamic_axes,
+                do_constant_folding=True,
+                opset_version=opset,
+            )
+

--- a/modelscope/exporters/multi_modal/stable_diffusion_exporter.py
+++ b/modelscope/exporters/multi_modal/stable_diffusion_exporter.py
@@ -1,18 +1,17 @@
-from collections import OrderedDict
-from typing import Any, Dict, Mapping, Tuple
-
-from torch.utils.data.dataloader import default_collate
 import argparse
 import os
 import shutil
+from collections import OrderedDict
 from pathlib import Path
+from typing import Any, Dict, Mapping, Tuple
 
 import onnx
 import torch
+from diffusers import (OnnxRuntimeModel, OnnxStableDiffusionPipeline,
+                       StableDiffusionPipeline)
 from packaging import version
 from torch.onnx import export
-
-from diffusers import OnnxRuntimeModel, OnnxStableDiffusionPipeline, StableDiffusionPipeline
+from torch.utils.data.dataloader import default_collate
 
 from modelscope.exporters.builder import EXPORTERS
 from modelscope.exporters.torch_model_exporter import TorchModelExporter
@@ -22,7 +21,8 @@ from modelscope.utils.constant import ModeKeys, Tasks
 from modelscope.utils.hub import snapshot_download
 
 
-@EXPORTERS.register_module(Tasks.text_to_image_synthesis, module_name=Models.stable_diffusion)
+@EXPORTERS.register_module(
+    Tasks.text_to_image_synthesis, module_name=Models.stable_diffusion)
 class StableDiffuisonExporter(TorchModelExporter):
 
     @torch.no_grad()
@@ -42,35 +42,41 @@ class StableDiffuisonExporter(TorchModelExporter):
         # Conversion weight accuracy.
         dtype = torch.float16 if fp16 else torch.float32
         if fp16 and torch.cuda.is_available():
-            device = "cuda"
+            device = 'cuda'
         elif fp16 and not torch.cuda.is_available():
-            raise ValueError("`float16` model export is only supported on GPUs with CUDA")
+            raise ValueError(
+                '`float16` model export is only supported on GPUs with CUDA')
         else:
-            device = "cpu"
+            device = 'cpu'
         # download and load models
         if not os.path.isdir(model_path):
             model_path = snapshot_download(model_path)
-        pipeline = StableDiffusionPipeline.from_pretrained(model_path, torch_dtype=dtype).to(device)
+        pipeline = StableDiffusionPipeline.from_pretrained(
+            model_path, torch_dtype=dtype).to(device)
         output_path = Path(output_path)
 
         # Text encoder
         num_tokens = pipeline.text_encoder.config.max_position_embeddings
         text_hidden_size = pipeline.text_encoder.config.hidden_size
         text_input = pipeline.tokenizer(
-            "A sample prompt",
-            padding="max_length",
+            'A sample prompt',
+            padding='max_length',
             max_length=pipeline.tokenizer.model_max_length,
             truncation=True,
-            return_tensors="pt",
+            return_tensors='pt',
         )
         self.export_help(
             pipeline.text_encoder,
-            model_args=(text_input.input_ids.to(device=device, dtype=torch.int32)),
-            output_path=output_path / "text_encoder" / "model.onnx",
-            ordered_input_names=["input_ids"],
-            output_names=["last_hidden_state", "pooler_output"],
+            model_args=(text_input.input_ids.to(
+                device=device, dtype=torch.int32)),
+            output_path=output_path / 'text_encoder' / 'model.onnx',
+            ordered_input_names=['input_ids'],
+            output_names=['last_hidden_state', 'pooler_output'],
             dynamic_axes={
-                "input_ids": {0: "batch", 1: "sequence"},
+                'input_ids': {
+                    0: 'batch',
+                    1: 'sequence'
+                },
             },
             opset=opset,
         )
@@ -79,25 +85,42 @@ class StableDiffuisonExporter(TorchModelExporter):
         # UNET
         unet_in_channels = pipeline.unet.config.in_channels
         unet_sample_size = pipeline.unet.config.sample_size
-        unet_path = output_path / "unet" / "model.onnx"
+        unet_path = output_path / 'unet' / 'model.onnx'
         self.export_help(
             pipeline.unet,
             model_args=(
-                torch.randn(2, unet_in_channels, unet_sample_size, unet_sample_size).to(device=device, dtype=dtype),
+                torch.randn(2, unet_in_channels, unet_sample_size,
+                            unet_sample_size).to(device=device, dtype=dtype),
                 torch.randn(2).to(device=device, dtype=dtype),
-                torch.randn(2, num_tokens, text_hidden_size).to(device=device, dtype=dtype),
+                torch.randn(2, num_tokens,
+                            text_hidden_size).to(device=device, dtype=dtype),
                 False,
             ),
             output_path=unet_path,
-            ordered_input_names=["sample", "timestep", "encoder_hidden_states", "return_dict"],
-            output_names=["out_sample"],  # has to be different from "sample" for correct tracing
+            ordered_input_names=[
+                'sample', 'timestep', 'encoder_hidden_states', 'return_dict'
+            ],
+            output_names=[
+                'out_sample'
+            ],  # has to be different from "sample" for correct tracing
             dynamic_axes={
-                "sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
-                "timestep": {0: "batch"},
-                "encoder_hidden_states": {0: "batch", 1: "sequence"},
+                'sample': {
+                    0: 'batch',
+                    1: 'channels',
+                    2: 'height',
+                    3: 'width'
+                },
+                'timestep': {
+                    0: 'batch'
+                },
+                'encoder_hidden_states': {
+                    0: 'batch',
+                    1: 'sequence'
+                },
             },
             opset=opset,
-            use_external_data_format=True,  # UNet is > 2GB, so the weights need to be split
+            use_external_data_format=
+            True,  # UNet is > 2GB, so the weights need to be split
         )
         unet_model_path = str(unet_path.absolute().as_posix())
         unet_dir = os.path.dirname(unet_model_path)
@@ -111,7 +134,7 @@ class StableDiffuisonExporter(TorchModelExporter):
             unet_model_path,
             save_as_external_data=True,
             all_tensors_to_one_file=True,
-            location="weights.pb",
+            location='weights.pb',
             convert_attribute=False,
         )
         del pipeline.unet
@@ -121,18 +144,25 @@ class StableDiffuisonExporter(TorchModelExporter):
         vae_in_channels = vae_encoder.config.in_channels
         vae_sample_size = vae_encoder.config.sample_size
         # need to get the raw tensor output (sample) from the encoder
-        vae_encoder.forward = lambda sample, return_dict: vae_encoder.encode(sample, return_dict)[0].sample()
+        vae_encoder.forward = lambda sample, return_dict: vae_encoder.encode(
+            sample, return_dict)[0].sample()
         self.export_help(
             vae_encoder,
             model_args=(
-                torch.randn(1, vae_in_channels, vae_sample_size, vae_sample_size).to(device=device, dtype=dtype),
+                torch.randn(1, vae_in_channels, vae_sample_size,
+                            vae_sample_size).to(device=device, dtype=dtype),
                 False,
             ),
-            output_path=output_path / "vae_encoder" / "model.onnx",
-            ordered_input_names=["sample", "return_dict"],
-            output_names=["latent_sample"],
+            output_path=output_path / 'vae_encoder' / 'model.onnx',
+            ordered_input_names=['sample', 'return_dict'],
+            output_names=['latent_sample'],
             dynamic_axes={
-                "sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+                'sample': {
+                    0: 'batch',
+                    1: 'channels',
+                    2: 'height',
+                    3: 'width'
+                },
             },
             opset=opset,
         )
@@ -146,14 +176,20 @@ class StableDiffuisonExporter(TorchModelExporter):
         self.export_help(
             vae_decoder,
             model_args=(
-                torch.randn(1, vae_latent_channels, unet_sample_size, unet_sample_size).to(device=device, dtype=dtype),
+                torch.randn(1, vae_latent_channels, unet_sample_size,
+                            unet_sample_size).to(device=device, dtype=dtype),
                 False,
             ),
-            output_path=output_path / "vae_decoder" / "model.onnx",
-            ordered_input_names=["latent_sample", "return_dict"],
-            output_names=["sample"],
+            output_path=output_path / 'vae_decoder' / 'model.onnx',
+            ordered_input_names=['latent_sample', 'return_dict'],
+            output_names=['sample'],
             dynamic_axes={
-                "latent_sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+                'latent_sample': {
+                    0: 'batch',
+                    1: 'channels',
+                    2: 'height',
+                    3: 'width'
+                },
             },
             opset=opset,
         )
@@ -174,30 +210,46 @@ class StableDiffuisonExporter(TorchModelExporter):
                         clip_image_size,
                         clip_image_size,
                     ).to(device=device, dtype=dtype),
-                    torch.randn(1, vae_sample_size, vae_sample_size, vae_out_channels).to(device=device, dtype=dtype),
+                    torch.randn(1, vae_sample_size, vae_sample_size,
+                                vae_out_channels).to(
+                                    device=device, dtype=dtype),
                 ),
-                output_path=output_path / "safety_checker" / "model.onnx",
-                ordered_input_names=["clip_input", "images"],
-                output_names=["out_images", "has_nsfw_concepts"],
+                output_path=output_path / 'safety_checker' / 'model.onnx',
+                ordered_input_names=['clip_input', 'images'],
+                output_names=['out_images', 'has_nsfw_concepts'],
                 dynamic_axes={
-                    "clip_input": {0: "batch", 1: "channels", 2: "height", 3: "width"},
-                    "images": {0: "batch", 1: "height", 2: "width", 3: "channels"},
+                    'clip_input': {
+                        0: 'batch',
+                        1: 'channels',
+                        2: 'height',
+                        3: 'width'
+                    },
+                    'images': {
+                        0: 'batch',
+                        1: 'height',
+                        2: 'width',
+                        3: 'channels'
+                    },
                 },
                 opset=opset,
             )
             del pipeline.safety_checker
-            safety_checker = OnnxRuntimeModel.from_pretrained(output_path / "safety_checker")
+            safety_checker = OnnxRuntimeModel.from_pretrained(
+                output_path / 'safety_checker')
             feature_extractor = pipeline.feature_extractor
         else:
             safety_checker = None
             feature_extractor = None
 
         onnx_pipeline = OnnxStableDiffusionPipeline(
-            vae_encoder=OnnxRuntimeModel.from_pretrained(output_path / "vae_encoder"),
-            vae_decoder=OnnxRuntimeModel.from_pretrained(output_path / "vae_decoder"),
-            text_encoder=OnnxRuntimeModel.from_pretrained(output_path / "text_encoder"),
+            vae_encoder=OnnxRuntimeModel.from_pretrained(output_path
+                                                         / 'vae_encoder'),
+            vae_decoder=OnnxRuntimeModel.from_pretrained(output_path
+                                                         / 'vae_decoder'),
+            text_encoder=OnnxRuntimeModel.from_pretrained(output_path
+                                                          / 'text_encoder'),
             tokenizer=pipeline.tokenizer,
-            unet=OnnxRuntimeModel.from_pretrained(output_path / "unet"),
+            unet=OnnxRuntimeModel.from_pretrained(output_path / 'unet'),
             scheduler=pipeline.scheduler,
             safety_checker=safety_checker,
             feature_extractor=feature_extractor,
@@ -205,12 +257,13 @@ class StableDiffuisonExporter(TorchModelExporter):
         )
 
         onnx_pipeline.save_pretrained(output_path)
-        print("ONNX pipeline saved to", output_path)
+        print('ONNX pipeline saved to', output_path)
 
         del pipeline
         del onnx_pipeline
-        _ = OnnxStableDiffusionPipeline.from_pretrained(output_path, provider="CPUExecutionProvider")
-        print("ONNX pipeline is loadable")
+        _ = OnnxStableDiffusionPipeline.from_pretrained(
+            output_path, provider='CPUExecutionProvider')
+        print('ONNX pipeline is loadable')
 
     def export_help(
         self,
@@ -225,7 +278,9 @@ class StableDiffuisonExporter(TorchModelExporter):
     ):
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        is_torch_less_than_1_11 = version.parse(version.parse(torch.__version__).base_version) < version.parse("1.11")
+        is_torch_less_than_1_11 = version.parse(
+            version.parse(
+                torch.__version__).base_version) < version.parse('1.11')
         if is_torch_less_than_1_11:
             export(
                 model,

--- a/modelscope/exporters/multi_modal/stable_diffusion_exporter.py
+++ b/modelscope/exporters/multi_modal/stable_diffusion_exporter.py
@@ -26,10 +26,10 @@ from modelscope.utils.hub import snapshot_download
 class StableDiffuisonExporter(TorchModelExporter):
 
     @torch.no_grad()
-    def export_onnx(self, 
-                    model_path: str, 
-                    output_path: str, 
-                    opset: int = 14, 
+    def export_onnx(self,
+                    model_path: str,
+                    output_path: str,
+                    opset: int = 14,
                     fp16: bool = False):
         """Export the model as onnx format files.
 
@@ -39,7 +39,6 @@ class StableDiffuisonExporter(TorchModelExporter):
             opset: The version of the ONNX operator set to use.
             fp16: Whether to use float16.
         """
-        
         # Conversion weight accuracy.
         dtype = torch.float16 if fp16 else torch.float32
         if fp16 and torch.cuda.is_available():
@@ -48,7 +47,6 @@ class StableDiffuisonExporter(TorchModelExporter):
             raise ValueError("`float16` model export is only supported on GPUs with CUDA")
         else:
             device = "cpu"
-        
         # download and load models
         if not os.path.isdir(model_path):
             model_path = snapshot_download(model_path)
@@ -67,7 +65,6 @@ class StableDiffuisonExporter(TorchModelExporter):
         )
         self.export_help(
             pipeline.text_encoder,
-            # casting to torch.int32 until the CLIP fix is released: https://github.com/huggingface/transformers/pull/18515/files
             model_args=(text_input.input_ids.to(device=device, dtype=torch.int32)),
             output_path=output_path / "text_encoder" / "model.onnx",
             ordered_input_names=["input_ids"],
@@ -253,4 +250,3 @@ class StableDiffuisonExporter(TorchModelExporter):
                 do_constant_folding=True,
                 opset_version=opset,
             )
-

--- a/modelscope/models/multi_modal/stable_diffusion/stable_diffusion.py
+++ b/modelscope/models/multi_modal/stable_diffusion/stable_diffusion.py
@@ -57,6 +57,7 @@ class StableDiffusion(TorchModel):
             pretrained_model_name_or_path, subfolder='vae', revision=revision)
         self.unet = UNet2DConditionModel.from_pretrained(
             pretrained_model_name_or_path, subfolder='unet', revision=revision)
+        self.safety_checker = None
 
         # Freeze gradient calculation and move to device
         if self.vae is not None:

--- a/tests/export/test_export_stable_diffusion.py
+++ b/tests/export/test_export_stable_diffusion.py
@@ -1,0 +1,30 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+import os
+import shutil
+import tempfile
+import unittest
+from collections import OrderedDict
+
+from modelscope.exporters import Exporter
+from modelscope.models import Model
+from modelscope.utils.constant import Tasks
+from modelscope.utils.test_utils import test_level
+
+
+class TestExportStableDiffusion(unittest.TestCase):
+
+    def setUp(self):
+        print(('Testing %s.%s' % (type(self).__name__, self._testMethodName)))
+        self.tmp_dir = tempfile.TemporaryDirectory().name
+        if not os.path.exists(self.tmp_dir):
+            os.makedirs(self.tmp_dir)
+        self.model_id = 'AI-ModelScope/stable-diffusion-v1-5'
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_export_stable_diffusion(self):
+        model = Model.from_pretrained(self.model_id)
+        print(Exporter.from_model(model).export_onnx(output_dir=self.tmp_dir))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/export/test_export_stable_diffusion.py
+++ b/tests/export/test_export_stable_diffusion.py
@@ -23,7 +23,8 @@ class TestExportStableDiffusion(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_export_stable_diffusion(self):
         model = Model.from_pretrained(self.model_id)
-        print(Exporter.from_model(model).export_onnx(output_dir=self.tmp_dir))
+        Exporter.from_model(model).export_onnx(
+            output_path=self.tmp_dir, opset=14)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Supports stable diffusion model checkpoint export as onnx models. 
The sample script is as follows:
```bash
from modelscope.models import Model
from modelscope.exporters import Exporter

model_id = 'AI-ModelScope/stable-diffusion-v1-5'
model = Model.from_pretrained(model_id)
Exporter.from_model(model).export_onnx(output_path='./tmp/onnx_output', opset=14)
```