### PR TITLE
Fix a bug of loading local stable diffusion dataset

### DIFF
--- a/examples/pytorch/stable_diffusion/dreambooth/finetune_stable_diffusion_dreambooth.py
+++ b/examples/pytorch/stable_diffusion/dreambooth/finetune_stable_diffusion_dreambooth.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass, field
 
 import cv2
@@ -63,14 +64,20 @@ training_args = StableDiffusionDreamboothArguments(
     task='text-to-image-synthesis').parse_cli()
 config, args = training_args.to_config()
 
-train_dataset = MsDataset.load(
-    args.train_dataset_name,
-    split='train',
-    download_mode=DownloadMode.FORCE_REDOWNLOAD)
-validation_dataset = MsDataset.load(
-    args.train_dataset_name,
-    split='validation',
-    download_mode=DownloadMode.FORCE_REDOWNLOAD)
+if os.path.exists(args.train_dataset_name):
+    # Load local dataset
+    train_dataset = MsDataset.load(args.train_dataset_name)
+    validation_dataset = MsDataset.load(args.train_dataset_name)
+else:
+    # Load online dataset
+    train_dataset = MsDataset.load(
+        args.train_dataset_name,
+        split='train',
+        download_mode=DownloadMode.FORCE_REDOWNLOAD)
+    validation_dataset = MsDataset.load(
+        args.train_dataset_name,
+        split='validation',
+        download_mode=DownloadMode.FORCE_REDOWNLOAD)
 
 
 def cfg_modify_fn(cfg):

--- a/examples/pytorch/stable_diffusion/lora/finetune_stable_diffusion_lora.py
+++ b/examples/pytorch/stable_diffusion/lora/finetune_stable_diffusion_lora.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass, field
 
 import cv2
@@ -23,14 +24,20 @@ training_args = StableDiffusionLoraArguments(
     task='text-to-image-synthesis').parse_cli()
 config, args = training_args.to_config()
 
-train_dataset = MsDataset.load(
-    args.train_dataset_name,
-    split='train',
-    download_mode=DownloadMode.FORCE_REDOWNLOAD)
-validation_dataset = MsDataset.load(
-    args.train_dataset_name,
-    split='validation',
-    download_mode=DownloadMode.FORCE_REDOWNLOAD)
+if os.path.exists(args.train_dataset_name):
+    # Load local dataset
+    train_dataset = MsDataset.load(args.train_dataset_name)
+    validation_dataset = MsDataset.load(args.train_dataset_name)
+else:
+    # Load online dataset
+    train_dataset = MsDataset.load(
+        args.train_dataset_name,
+        split='train',
+        download_mode=DownloadMode.FORCE_REDOWNLOAD)
+    validation_dataset = MsDataset.load(
+        args.train_dataset_name,
+        split='validation',
+        download_mode=DownloadMode.FORCE_REDOWNLOAD)
 
 
 def cfg_modify_fn(cfg):


### PR DESCRIPTION
Before fixing this bug, an error will be reported as follows: 

```
Traceback (most recent call last):
  File "examples/pytorch/stable_diffusion/dreambooth/finetune_stable_diffusion_dreambooth.py", line 89, in <module>
    download_mode=DownloadMode.FORCE_REDOWNLOAD)
  File "/mnt/user/E-yijing.wq-401594/github/sd_data_bug/modelscope/modelscope/msdatasets/ms_dataset.py", line 258, in load
    LocalDataLoaderType.HF_DATA_LOADER)
  File "/mnt/user/E-yijing.wq-401594/github/sd_data_bug/modelscope/modelscope/msdatasets/data_loader/data_loader_manager.py", line 85, in load_dataset
    **input_config_kwargs)
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/load.py", line 1769, in load_dataset
    ds = builder_instance.as_dataset(split=split, ignore_verifications=ignore_verifications, in_memory=keep_in_memory)
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/builder.py", line 1075, in as_dataset
    disable_tqdm=not logging.is_progress_bar_enabled(),
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/utils/py_utils.py", line 436, in map_nested
    return function(data_struct)
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/builder.py", line 1099, in _build_single_dataset
    in_memory=in_memory,
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/builder.py", line 1172, in _as_dataset
    in_memory=in_memory,
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/arrow_reader.py", line 235, in read
    files = self.get_file_instructions(name, instructions, split_infos)
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/arrow_reader.py", line 209, in get_file_instructions
    name, split_infos, instruction, filetype_suffix=self._filetype_suffix, prefix_path=self._path
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/arrow_reader.py", line 125, in make_file_instructions
    absolute_instructions = instruction.to_absolute(name2len)
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/arrow_reader.py", line 648, in to_absolute
    return [_rel_to_abs_instr(rel_instr, name2len) for rel_instr in self._relative_instructions]
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/arrow_reader.py", line 648, in <listcomp>
    return [_rel_to_abs_instr(rel_instr, name2len) for rel_instr in self._relative_instructions]
  File "/opt/conda/envs/modelscope/lib/python3.7/site-packages/datasets/arrow_reader.py", line 460, in _rel_to_abs_instr
    raise ValueError(f'Unknown split "{split}". Should be one of {list(name2len)}.')
ValueError: Unknown split "validation". Should be one of ['train'].
```