### PR TITLE
Update speaker_verification_pipeline.py

### DIFF
--- a/modelscope/pipelines/audio/speaker_diarization_pipeline.py
+++ b/modelscope/pipelines/audio/speaker_diarization_pipeline.py
@@ -232,7 +232,12 @@ class SpeakerDiarizationPipeline(Pipeline):
     def forward(self, audio_in: Union[tuple, str, Any] = None) -> list:
         """Decoding
         """
-        logger.info('Speaker Diarization Processing: {0} ...'.format(audio_in))
+        # log  file_path/url or tuple (str, str)
+        if isinstance(audio_in, str) or \
+                (isinstance(audio_in, tuple) and all(isinstance(item, str) for item in audio_in)):
+            logger.info(f'Speaker Verification Processing: {audio_in} ...')
+        else:
+            logger.info(f'Speaker Verification Processing: {str(audio_in)[:100]} ...')
 
         data_cmd, raw_inputs = None, None
         if isinstance(audio_in, tuple) or isinstance(audio_in, list):

--- a/modelscope/pipelines/audio/speaker_verification_pipeline.py
+++ b/modelscope/pipelines/audio/speaker_verification_pipeline.py
@@ -180,8 +180,14 @@ class SpeakerVerificationPipeline(Pipeline):
     def forward(self, audio_in: Union[tuple, str, Any] = None) -> list:
         """Decoding
         """
-        logger.info(
-            'Speaker Verification Processing: {0} ...'.format(str(audio_in)[:500]))
+        if isinstance(audio_in, str):
+            if os.path.isfile(audio_in) or audio_in.startswith("http") :
+                # 如果是文件路径或 URL，则输出 audio_in
+                logger.info(f'Speaker Verification Processing: {audio_in} ...')
+            else: # bytes
+                 logger.info(f'Speaker Verification Processing: {str(audio_in)[:50]} ...')
+        else: # tuple (str, str) or (bytes, bytes)
+            logger.info(f'Speaker Verification Processing: {str(audio_in)[:500]} ...')
 
         data_cmd, raw_inputs = None, None
         if isinstance(audio_in, tuple) or isinstance(audio_in, list):

--- a/modelscope/pipelines/audio/speaker_verification_pipeline.py
+++ b/modelscope/pipelines/audio/speaker_verification_pipeline.py
@@ -181,7 +181,7 @@ class SpeakerVerificationPipeline(Pipeline):
         """Decoding
         """
         logger.info(
-            'Speaker Verification Processing: {0} ...'.format(audio_in))
+            'Speaker Verification Processing: {0} ...'.format(audio_in[500]))
 
         data_cmd, raw_inputs = None, None
         if isinstance(audio_in, tuple) or isinstance(audio_in, list):

--- a/modelscope/pipelines/audio/speaker_verification_pipeline.py
+++ b/modelscope/pipelines/audio/speaker_verification_pipeline.py
@@ -180,17 +180,13 @@ class SpeakerVerificationPipeline(Pipeline):
     def forward(self, audio_in: Union[tuple, str, Any] = None) -> list:
         """Decoding
         """
-        if isinstance(audio_in, str):
-            if os.path.isfile(audio_in) or audio_in.startswith('http'):
-                # 如果是文件路径或 URL，则输出 audio_in
-                logger.info(f'Speaker Verification Processing: {audio_in} ...')
-            else:  # bytes
-                logger.info(
-                    f'Speaker Verification Processing: {str(audio_in)[:50]} ...'
-                )
-        else:  # tuple (str, str) or (bytes, bytes)
+        # log  file_path/url or tuple (str, str)
+        if isinstance(audio_in, str) or \
+                (isinstance(audio_in, tuple) and all(isinstance(item, str) for item in audio_in)):
+            logger.info(f'Speaker Verification Processing: {audio_in} ...')
+        else:
             logger.info(
-                f'Speaker Verification Processing: {str(audio_in)[:500]} ...')
+                f'Speaker Verification Processing: {str(audio_in)[:100]} ...')
 
         data_cmd, raw_inputs = None, None
         if isinstance(audio_in, tuple) or isinstance(audio_in, list):

--- a/modelscope/pipelines/audio/speaker_verification_pipeline.py
+++ b/modelscope/pipelines/audio/speaker_verification_pipeline.py
@@ -181,13 +181,16 @@ class SpeakerVerificationPipeline(Pipeline):
         """Decoding
         """
         if isinstance(audio_in, str):
-            if os.path.isfile(audio_in) or audio_in.startswith("http") :
+            if os.path.isfile(audio_in) or audio_in.startswith('http'):
                 # 如果是文件路径或 URL，则输出 audio_in
                 logger.info(f'Speaker Verification Processing: {audio_in} ...')
-            else: # bytes
-                 logger.info(f'Speaker Verification Processing: {str(audio_in)[:50]} ...')
-        else: # tuple (str, str) or (bytes, bytes)
-            logger.info(f'Speaker Verification Processing: {str(audio_in)[:500]} ...')
+            else:  # bytes
+                logger.info(
+                    f'Speaker Verification Processing: {str(audio_in)[:50]} ...'
+                )
+        else:  # tuple (str, str) or (bytes, bytes)
+            logger.info(
+                f'Speaker Verification Processing: {str(audio_in)[:500]} ...')
 
         data_cmd, raw_inputs = None, None
         if isinstance(audio_in, tuple) or isinstance(audio_in, list):

--- a/modelscope/pipelines/audio/speaker_verification_pipeline.py
+++ b/modelscope/pipelines/audio/speaker_verification_pipeline.py
@@ -181,7 +181,7 @@ class SpeakerVerificationPipeline(Pipeline):
         """Decoding
         """
         logger.info(
-            'Speaker Verification Processing: {0} ...'.format(audio_in[500]))
+            'Speaker Verification Processing: {0} ...'.format(audio_in[:500]))
 
         data_cmd, raw_inputs = None, None
         if isinstance(audio_in, tuple) or isinstance(audio_in, list):

--- a/modelscope/pipelines/audio/speaker_verification_pipeline.py
+++ b/modelscope/pipelines/audio/speaker_verification_pipeline.py
@@ -181,7 +181,7 @@ class SpeakerVerificationPipeline(Pipeline):
         """Decoding
         """
         logger.info(
-            'Speaker Verification Processing: {0} ...'.format(audio_in[:500]))
+            'Speaker Verification Processing: {0} ...'.format(str(audio_in)[:500]))
 
         data_cmd, raw_inputs = None, None
         if isinstance(audio_in, tuple) or isinstance(audio_in, list):


### PR DESCRIPTION
fix log too long when input tuple(bytes,bytes)

when input ( bytes,bytes) logger will print all byte ....

I think 500 words for URL / file path check  is enough... if want use print file/url path can use:

```
    # 判断 audio_in 是否为文件路径或 URL
    if isinstance(audio_in, str):
        parsed_url = urlparse(audio_in)
        if os.path.isfile(audio_in) or (parsed_url.scheme and parsed_url.netloc):
            # 如果是文件路径或 URL，则输出 audio_in
            logger.info(f'Speaker Verification Processing: {audio_in} ...')
        else:
            # 如果不是文件路径或 URL，则输出数据的前500字节
             logger.info(f'Speaker Verification Processing: {str(audio_in)[:500]} ...')
    else:
        # 如果不是文件路径或 URL，tuple or bytes 则输出数据的前500字节
        logger.info(f'Speaker Verification Processing: {str(audio_in)[:500]} ...')
```