### PR TITLE
Fix bugs of chinese stable diffusion pipeline getting an unexpected keyword argument 'lora_scale'

### DIFF
--- a/modelscope/pipelines/multi_modal/diffusers_wrapped/stable_diffusion/chinese_stable_diffusion_pipeline.py
+++ b/modelscope/pipelines/multi_modal/diffusers_wrapped/stable_diffusion/chinese_stable_diffusion_pipeline.py
@@ -146,7 +146,8 @@ class _DiffuersChineseStableDiffusionPipeline(StableDiffusionPipeline):
             do_classifier_free_guidance,
             negative_prompt=None,
             prompt_embeds: Optional[torch.FloatTensor] = None,
-            negative_prompt_embeds: Optional[torch.FloatTensor] = None):
+            negative_prompt_embeds: Optional[torch.FloatTensor] = None,
+            lora_scale: Optional[float] = None):
         r"""
         Encodes the prompt into text encoder hidden states.
 
@@ -169,7 +170,14 @@ class _DiffuersChineseStableDiffusionPipeline(StableDiffusionPipeline):
                 Pre-generated negative text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt
                 weighting. If not provided, negative_prompt_embeds will be generated from `negative_prompt` input
                 argument.
+            lora_scale (`float`, *optional*):
+                A lora scale that will be applied to all LoRA layers of the text encoder if LoRA layers are loaded.
         """
+        # set lora scale so that monkey patched LoRA
+        # function of text encoder can correctly access it
+        if lora_scale is not None and isinstance(self, LoraLoaderMixin):
+            self._lora_scale = lora_scale
+
         if prompt is not None and isinstance(prompt, str):
             batch_size = 1
         elif prompt is not None and isinstance(prompt, list):


### PR DESCRIPTION
If this bug is not fixed, the following error message will be displayed: 
```
2023-07-15T12:44:41.0165972Z Case pipelines.test_chinese_stable_diffusion.ChineseStableDiffusionTest.test_run_default run result: Error, msg:
2023-07-15T12:44:41.0166806Z Traceback (most recent call last):
2023-07-15T12:44:41.0167454Z   File "/[Ma](https://github.com/modelscope/modelscope/pull/387#)[as](https://github.com/modelscope/modelscope/pull/387#)-lib/tests/pipelines/test_chinese_stable_diffusion.py", line 21, in test_run_default
2023-07-15T12:44:41.0167926Z     output = pipe({'text': '中国山水画'})
2023-07-15T12:44:41.0168703Z   File "/opt/conda/lib/python3.8/site-packages/modelscope/pipelines/multi_modal/diffusers_wrapped/diffusers_pipeline.py", line 54, in __call__
2023-07-15T12:44:41.0169106Z     out = self.forward(out, **forward_params)
2023-07-15T12:44:41.0169853Z   File "/opt/conda/lib/python3.8/site-packages/modelscope/pipelines/multi_modal/diffusers_wrapped/stable_diffusion/chinese_stable_diffusion_pipeline.py", line 62, in forward
2023-07-15T12:44:41.0170371Z     return self.pipeline(
2023-07-15T12:44:41.0170833Z   File "/opt/conda/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
2023-07-15T12:44:41.0171183Z     return func(*args, **kwargs)
2023-07-15T12:44:41.0171725Z   File "/opt/conda/lib/python3.8/site-packages/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py", line 688, in __call__
2023-07-15T12:44:41.0172122Z     prompt_embeds = self._encode_prompt(
2023-07-15T12:44:41.0172535Z TypeError: _encode_prompt() got an unexpected keyword argument 'lora_scale'
2023-07-15T12:44:41.0172755Z 
2023-07-15T12:44:41.0173033Z Case pipelines.test_chinese_stable_diffusion.ChineseStableDiffusionTest.test_run_dpmsolver run result: Error, msg:
2023-07-15T12:44:41.0173441Z Traceback (most recent call last):
2023-07-15T12:44:41.0173893Z   File "/Maas-lib/tests/pipelines/test_chinese_stable_diffusion.py", line 31, in test_run_dpmsolver
2023-07-15T12:44:41.0174380Z     output = pipe({'text': '中国山水画', 'num_inference_steps': 25})
2023-07-15T12:44:41.0174977Z   File "/opt/conda/lib/python3.8/site-packages/modelscope/pipelines/multi_modal/diffusers_wrapped/diffusers_pipeline.py", line 54, in __call__
2023-07-15T12:44:41.0175393Z     out = self.forward(out, **forward_params)
2023-07-15T12:44:41.0176010Z   File "/opt/conda/lib/python3.8/site-packages/modelscope/pipelines/multi_modal/diffusers_wrapped/stable_diffusion/chinese_stable_diffusion_pipeline.py", line 62, in forward
2023-07-15T12:44:41.0176531Z     return self.pipeline(
2023-07-15T12:44:41.0177005Z   File "/opt/conda/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
2023-07-15T12:44:41.0177458Z     return func(*args, **kwargs)
2023-07-15T12:44:41.0177983Z   File "/opt/conda/lib/python3.8/site-packages/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py", line 688, in __call__
2023-07-15T12:44:41.0178379Z     prompt_embeds = self._encode_prompt(
2023-07-15T12:44:41.0178814Z TypeError: _encode_prompt() got an unexpected keyword argument 'lora_scale'
```