### PR TITLE
ckpt output directory ignore *.safetensors

### DIFF
--- a/examples/pytorch/llm/_common.py
+++ b/examples/pytorch/llm/_common.py
@@ -394,7 +394,11 @@ def get_model_tokenizer(model_type: str,
         model, tokenizer = get_chatglm2_model_tokenizer(
             model_dir, load_model, add_special_token, torch_dtype)
     elif model_type == 'llama2-7b':
-        model_dir = snapshot_download('modelscope/Llama-2-7b-ms', 'v1.0.2')
+        # use `.safetensors`
+        model_dir = snapshot_download(
+            'modelscope/Llama-2-7b-ms',
+            'v1.0.2',
+            ignore_file_pattern=[r'.+\.bin$'])
         model, tokenizer = get_llama2_model_tokenizer(model_dir, load_model,
                                                       add_special_token,
                                                       torch_dtype)

--- a/examples/pytorch/llm/_common.py
+++ b/examples/pytorch/llm/_common.py
@@ -468,13 +468,13 @@ def tensorboard_smoothing(values: List[float],
     return res
 
 
-def plot_image(tb_dir: str,
-               smooth_key: List[str],
-               smooth_val: float = 0.9,
-               figsize: Tuple[int, int] = (8, 5),
-               dpi: int = 100) -> None:
-    image_dir = os.path.join(os.path.dirname(tb_dir), 'images')
-    os.makedirs(image_dir, exist_ok=True)
+def plot_images(tb_dir: str,
+                smooth_key: List[str],
+                smooth_val: float = 0.9,
+                figsize: Tuple[int, int] = (8, 5),
+                dpi: int = 100) -> None:
+    images_dir = os.path.join(os.path.dirname(tb_dir), 'images')
+    os.makedirs(images_dir, exist_ok=True)
 
     fname = os.listdir(tb_dir)[0]
     tb_path = os.path.join(tb_dir, fname)
@@ -496,7 +496,7 @@ def plot_image(tb_dir: str,
             ax.plot(steps, values_s, color=COLOR_S)
         else:
             ax.plot(steps, values, color=COLOR_S)
-        fpath = os.path.join(image_dir, k.replace('/', '_'))
+        fpath = os.path.join(images_dir, k.replace('/', '_'))
         plt.savefig(fpath, dpi=dpi, bbox_inches='tight')
 
 

--- a/examples/pytorch/llm/llm_infer.py
+++ b/examples/pytorch/llm/llm_infer.py
@@ -13,10 +13,10 @@ class InferArguments:
         })
     sft_type: str = field(
         default='lora', metadata={'choices': ['lora', 'full']})
-    ckpt_fpath: str = '/path/to/your/iter_xxx.pth'
+    ckpt_path: str = '/path/to/your/iter_xxx.pth'
     eval_human: bool = False  # False: eval test_dataset
     data_sample: Optional[int] = None
-    # sft_type: lora
+
     lora_target_modules: Optional[List[str]] = None
     lora_rank: int = 8
     lora_alpha: int = 32
@@ -38,8 +38,9 @@ class InferArguments:
             else:
                 raise ValueError(f'model_type: {self.model_type}')
 
-        if not os.path.isfile(self.ckpt_fpath):
-            raise ValueError(f'Please enter a valid fpath: {self.ckpt_fpath}')
+        if not os.path.isfile(self.ckpt_path):
+            raise ValueError(
+                f'Please enter a valid ckpt_path: {self.ckpt_path}')
 
 
 def parse_args() -> InferArguments:
@@ -69,11 +70,11 @@ def llm_infer(args: InferArguments) -> None:
             rank=args.lora_rank,
             lora_alpha=args.lora_alpha,
             lora_dropout=args.lora_dropout_p,
-            pretrained_weights=args.ckpt_fpath)
+            pretrained_weights=args.ckpt_path)
         logger.info(f'lora_config: {lora_config}')
         Swift.prepare_model(model, lora_config)
     elif args.sft_type == 'full':
-        state_dict = torch.load(args.ckpt_fpath, map_location='cpu')
+        state_dict = torch.load(args.ckpt_path, map_location='cpu')
         model.load_state_dict(state_dict)
     else:
         raise ValueError(f'args.sft_type: {args.sft_type}')

--- a/examples/pytorch/llm/llm_sft.py
+++ b/examples/pytorch/llm/llm_sft.py
@@ -260,7 +260,7 @@ def llm_sft(args: SftArguments) -> None:
 
     # ### Visualization
     tb_dir = os.path.join(work_dir, 'tensorboard_output')
-    plot_image(tb_dir, ['loss'], 0.9)
+    plot_images(tb_dir, ['loss'], 0.9)
 
 
 if __name__ == '__main__':

--- a/examples/pytorch/llm/run_infer.sh
+++ b/examples/pytorch/llm/run_infer.sh
@@ -1,5 +1,5 @@
 python llm_infer.py \
     --device 0 \
     --model_type llama2-7b \
-    --ckpt_fpath "runs/llama2-7b/vx_xxx/output_best/pytorch_model.bin" \
+    --ckpt_path "runs/llama2-7b/vx_xxx/output_best/pytorch_model.bin" \
     --eval_human true

--- a/modelscope/utils/checkpoint.py
+++ b/modelscope/utils/checkpoint.py
@@ -622,6 +622,7 @@ def save_pretrained(model,
     origin_file_to_be_ignored = [save_checkpoint_name]
     ignore_file_set = set(origin_file_to_be_ignored)
     ignore_file_set.add(ModelFile.CONFIGURATION)
+    ignore_file_set.add('*.safetensors')
     ignore_file_set.add('.*')
     if hasattr(model,
                'model_dir') and model.model_dir is not None and is_master():


### PR DESCRIPTION
1. ckpt output directory ignore *.safetensors  (save disk space)
2. Use device_kwargs instead of device='cpu' to improve readability
3. Use *.safetensors instead of *.bin files(not downloading) to save disk space