### PR TITLE
Support VLLM in LLMPipeline

### DIFF
--- a/modelscope/pipelines/accelerate/base.py
+++ b/modelscope/pipelines/accelerate/base.py
@@ -1,6 +1,6 @@
 import os.path
 from abc import abstractmethod
-from typing import List
+from typing import List, Union
 
 import torch.cuda
 
@@ -39,7 +39,7 @@ class InferFramework:
                 f'Model accelerating not supported: {model_id_or_dir}')
 
     @abstractmethod
-    def __call__(self, prompts: List[str], **kwargs) -> List[str]:
+    def __call__(self, prompts: Union[List[str], List[List[int]]], **kwargs) -> List[str]:
         """
         Args:
             prompts (`List[str]`): The prompts in batch to generate answers.

--- a/modelscope/pipelines/accelerate/base.py
+++ b/modelscope/pipelines/accelerate/base.py
@@ -1,0 +1,45 @@
+import os.path
+from abc import abstractmethod
+from typing import List
+
+import torch.cuda
+
+from modelscope import snapshot_download
+
+
+class InferFramework:
+
+    def __init__(self,
+                 model_id_or_dir,
+                 **kwargs):
+        """
+        Args:
+            model_id_or_dir(`str`): The model id of the modelhub or a local dir containing model files.
+        """
+        if os.path.exists(model_id_or_dir):
+            self.model_dir = model_id_or_dir
+        else:
+            self.model_dir = snapshot_download(model_id_or_dir)
+
+    @abstractmethod
+    def __call__(self, prompts: List[str], **kwargs) -> List[str]:
+        """
+        Args:
+            prompts (`List[str]`): The prompts in batch to generate answers.
+        Returns:
+            The answers in list according to the input prompt batch.
+        """
+        pass
+
+    @staticmethod
+    def check_gpu_compatibility(major_version: int):
+        major, _ = torch.cuda.get_device_capability()
+        return major >= major_version
+
+    @classmethod
+    def from_pretrained(cls, model_id_or_dir, **kwargs):
+        from .vllm import Vllm
+        return Vllm(model_id_or_dir, **kwargs)
+
+
+

--- a/modelscope/pipelines/accelerate/base.py
+++ b/modelscope/pipelines/accelerate/base.py
@@ -59,4 +59,6 @@ class InferFramework:
     @classmethod
     def from_pretrained(cls, model_id_or_dir, framework='vllm', **kwargs):
         from .vllm import Vllm
-        return Vllm(model_id_or_dir, **kwargs)
+        vllm = Vllm(model_id_or_dir, **kwargs)
+        vllm.llm_framework = framework
+        return vllm

--- a/modelscope/pipelines/accelerate/base.py
+++ b/modelscope/pipelines/accelerate/base.py
@@ -4,14 +4,13 @@ from typing import List
 
 import torch.cuda
 
-from modelscope import snapshot_download
+from modelscope import read_config, snapshot_download
+from modelscope.utils.config import Config
 
 
 class InferFramework:
 
-    def __init__(self,
-                 model_id_or_dir,
-                 **kwargs):
+    def __init__(self, model_id_or_dir, **kwargs):
         """
         Args:
             model_id_or_dir(`str`): The model id of the modelhub or a local dir containing model files.
@@ -20,6 +19,24 @@ class InferFramework:
             self.model_dir = model_id_or_dir
         else:
             self.model_dir = snapshot_download(model_id_or_dir)
+
+        model_supported = self.model_type_supported(model_id_or_dir)
+        config: Config = read_config(self.model_dir)
+        model_type = config.safe_get('model.type')
+        if model_type is not None:
+            model_supported = model_supported or self.model_type_supported(
+                model_type)
+        config_file = os.path.join(self.model_dir, 'config.json')
+        if os.path.isfile(config_file):
+            config = Config.from_file(config_file)
+            model_type = config.safe_get('model_type')
+            if model_type is not None:
+                model_supported = model_supported or self.model_type_supported(
+                    model_type)
+
+        if not model_supported:
+            raise ValueError(
+                f'Model accelerating not supported: {model_id_or_dir}')
 
     @abstractmethod
     def __call__(self, prompts: List[str], **kwargs) -> List[str]:
@@ -31,15 +48,15 @@ class InferFramework:
         """
         pass
 
+    def model_type_supported(self, model_type):
+        return False
+
     @staticmethod
     def check_gpu_compatibility(major_version: int):
         major, _ = torch.cuda.get_device_capability()
         return major >= major_version
 
     @classmethod
-    def from_pretrained(cls, model_id_or_dir, **kwargs):
+    def from_pretrained(cls, model_id_or_dir, framework='vllm', **kwargs):
         from .vllm import Vllm
         return Vllm(model_id_or_dir, **kwargs)
-
-
-

--- a/modelscope/pipelines/accelerate/vllm.py
+++ b/modelscope/pipelines/accelerate/vllm.py
@@ -27,8 +27,6 @@ class Vllm(InferFramework):
             quantization=quantization,
             trust_remote_code=True,
             tensor_parallel_size=tensor_parallel_size)
-        self.model.model_dir = self.model_dir
-        self.model.llm_framework = 'vllm'
 
     def __call__(self, prompts: Union[List[str], List[List[int]]], **kwargs) -> List[str]:
         from vllm import SamplingParams

--- a/modelscope/pipelines/accelerate/vllm.py
+++ b/modelscope/pipelines/accelerate/vllm.py
@@ -27,21 +27,6 @@ class Vllm(InferFramework):
             quantization=quantization,
             tensor_parallel_size=tensor_parallel_size)
 
-        self.supported_models = [
-            'llama',
-            'baichuan',
-            'internlm',
-            'mistral',
-            'aquila',
-            'bloom',
-            'falcon',
-            'gpt',
-            'mpt',
-            'opt',
-            'qwen',
-            'aquila',
-        ]
-
     def __call__(self, prompts: List[str], **kwargs) -> List[str]:
         from vllm import SamplingParams
         sampling_params = SamplingParams(**kwargs)
@@ -51,5 +36,19 @@ class Vllm(InferFramework):
         ]
 
     def model_type_supported(self, model_type: str):
-        return any(
-            [model in model_type.lower() for model in self.supported_models])
+        return any([
+            model in model_type.lower() for model in [
+                'llama',
+                'baichuan',
+                'internlm',
+                'mistral',
+                'aquila',
+                'bloom',
+                'falcon',
+                'gpt',
+                'mpt',
+                'opt',
+                'qwen',
+                'aquila',
+            ]
+        ])

--- a/modelscope/pipelines/accelerate/vllm.py
+++ b/modelscope/pipelines/accelerate/vllm.py
@@ -11,6 +11,12 @@ class Vllm(InferFramework):
                  dtype: str = 'auto',
                  quantization: str = None,
                  tensor_parallel_size: int = 1):
+        """
+        Args:
+            dtype: The dtype to use, support `auto`, `float16`, `bfloat16`, `float32`
+            quantization: The quantization bit, default None means do not do any quantization.
+            tensor_parallel_size: The tensor parallel size.
+        """
         super().__init__(model_id_or_dir)
         if not is_vllm_available():
             raise ImportError(
@@ -28,18 +34,25 @@ class Vllm(InferFramework):
             trust_remote_code=True,
             tensor_parallel_size=tensor_parallel_size)
 
-    def __call__(self, prompts: Union[List[str], List[List[int]]], **kwargs) -> List[str]:
+    def __call__(self, prompts: Union[List[str], List[List[int]]],
+                 **kwargs) -> List[str]:
+        """Generate tokens.
+        Args:
+            prompts(`Union[List[str], List[List[int]]]`):
+                The string batch or the token list batch to input to the model.
+            kwargs: Sampling parameters.
+        """
         from vllm import SamplingParams
         sampling_params = SamplingParams(**kwargs)
         if isinstance(prompts[0], str):
             return [
-                output.outputs[0].text
-                for output in self.model.generate(prompts, sampling_params=sampling_params)
+                output.outputs[0].text for output in self.model.generate(
+                    prompts, sampling_params=sampling_params)
             ]
         else:
             return [
-                output.outputs[0].text
-                for output in self.model.generate(prompt_token_ids=prompts, sampling_params=sampling_params)
+                output.outputs[0].text for output in self.model.generate(
+                    prompt_token_ids=prompts, sampling_params=sampling_params)
             ]
 
     def model_type_supported(self, model_type: str):

--- a/modelscope/pipelines/accelerate/vllm.py
+++ b/modelscope/pipelines/accelerate/vllm.py
@@ -27,6 +27,8 @@ class Vllm(InferFramework):
             quantization=quantization,
             trust_remote_code=True,
             tensor_parallel_size=tensor_parallel_size)
+        self.model.model_dir = self.model_dir
+        self.model.llm_framework = 'vllm'
 
     def __call__(self, prompts: Union[List[str], List[List[int]]], **kwargs) -> List[str]:
         from vllm import SamplingParams

--- a/modelscope/pipelines/accelerate/vllm.py
+++ b/modelscope/pipelines/accelerate/vllm.py
@@ -9,19 +9,47 @@ class Vllm(InferFramework):
     def __init__(self,
                  model_id_or_dir: str,
                  dtype: str = None,
-                 quantization:str = None,
+                 quantization: str = None,
                  tensor_parallel_size: int = None):
         super().__init__(model_id_or_dir)
         if not is_vllm_available():
-            raise ImportError(f'Install vllm by `pip install vllm` before using vllm to accelerate inference')
+            raise ImportError(
+                'Install vllm by `pip install vllm` before using vllm to accelerate inference'
+            )
 
         from vllm import LLM
-        if Vllm.check_gpu_compatibility(8) and (dtype is None or dtype == 'bfloat16'):
+        if Vllm.check_gpu_compatibility(8) and (dtype is None
+                                                or dtype == 'bfloat16'):
             dtype = 'float16'
-        self.model = LLM(self.model_dir, dtype=dtype,
-                         quantization=quantization, tensor_parallel_size=tensor_parallel_size)
+        self.model = LLM(
+            self.model_dir,
+            dtype=dtype,
+            quantization=quantization,
+            tensor_parallel_size=tensor_parallel_size)
+
+        self.supported_models = [
+            'llama',
+            'baichuan',
+            'internlm',
+            'mistral',
+            'aquila',
+            'bloom',
+            'falcon',
+            'gpt',
+            'mpt',
+            'opt',
+            'qwen',
+            'aquila',
+        ]
 
     def __call__(self, prompts: List[str], **kwargs) -> List[str]:
         from vllm import SamplingParams
         sampling_params = SamplingParams(**kwargs)
-        return [output.outputs[0].text for output in self.model.generate(prompts, sampling_params)]
+        return [
+            output.outputs[0].text
+            for output in self.model.generate(prompts, sampling_params)
+        ]
+
+    def model_type_supported(self, model_type: str):
+        return any(
+            [model in model_type.lower() for model in self.supported_models])

--- a/modelscope/pipelines/accelerate/vllm.py
+++ b/modelscope/pipelines/accelerate/vllm.py
@@ -8,9 +8,9 @@ class Vllm(InferFramework):
 
     def __init__(self,
                  model_id_or_dir: str,
-                 dtype: str = None,
+                 dtype: str = 'auto',
                  quantization: str = None,
-                 tensor_parallel_size: int = None):
+                 tensor_parallel_size: int = 1):
         super().__init__(model_id_or_dir)
         if not is_vllm_available():
             raise ImportError(
@@ -18,8 +18,8 @@ class Vllm(InferFramework):
             )
 
         from vllm import LLM
-        if Vllm.check_gpu_compatibility(8) and (dtype is None
-                                                or dtype == 'bfloat16'):
+        if not Vllm.check_gpu_compatibility(8) and (dtype
+                                                    in ('bfloat16', 'auto')):
             dtype = 'float16'
         self.model = LLM(
             self.model_dir,

--- a/modelscope/pipelines/accelerate/vllm.py
+++ b/modelscope/pipelines/accelerate/vllm.py
@@ -1,0 +1,27 @@
+from typing import List
+
+from modelscope.pipelines.accelerate.base import InferFramework
+from modelscope.utils.import_utils import is_vllm_available
+
+
+class Vllm(InferFramework):
+
+    def __init__(self,
+                 model_id_or_dir: str,
+                 dtype: str = None,
+                 quantization:str = None,
+                 tensor_parallel_size: int = None):
+        super().__init__(model_id_or_dir)
+        if not is_vllm_available():
+            raise ImportError(f'Install vllm by `pip install vllm` before using vllm to accelerate inference')
+
+        from vllm import LLM
+        if Vllm.check_gpu_compatibility(8) and (dtype is None or dtype == 'bfloat16'):
+            dtype = 'float16'
+        self.model = LLM(self.model_dir, dtype=dtype,
+                         quantization=quantization, tensor_parallel_size=tensor_parallel_size)
+
+    def __call__(self, prompts: List[str], **kwargs) -> List[str]:
+        from vllm import SamplingParams
+        sampling_params = SamplingParams(**kwargs)
+        return [output.outputs[0].text for output in self.model.generate(prompts, sampling_params)]

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -164,7 +164,8 @@ class LLMPipeline(Pipeline):
             else:
                 raise ValueError('model does not support `generate`!')
         else:
-            outputs = self.model(tokens, **forward_params)
+            tokens = [list(tokens['inputs'].flatten().numpy())]
+            outputs = self.model(tokens, **forward_params)[0]
 
         if not isinstance(outputs, str):
             outputs = outputs.tolist()[0][len(tokens['inputs'][0]):]

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -82,6 +82,11 @@ class LLMPipeline(Pipeline):
         self.cfg = Config.from_file(cfg_file)
         return self.cfg.safe_get('adapter_cfg.tuner_backend') == 'swift'
 
+    def _wrap_infer_framework(self, model_dir, framework='vllm'):
+        if framework == 'vllm':
+            engine_args = AsyncEngineArgs.from_cli_args(args)
+            engine = AsyncLLMEngine.from_engine_args(engine_args)
+
     def __init__(self,
                  format_messages: Union[Callable, str] = None,
                  format_output: Callable = None,

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -185,6 +185,8 @@ class LLMPipeline(Pipeline):
         elif hasattr(self.model, 'model') and hasattr(self.model.model,
                                                       'device'):
             device = self.model.model.device
+        elif hasattr(self.model, 'llm_framework'):
+            device = 'cuda:0'
         else:
             raise ValueError('model does not have `device` attribute!')
         return {k: v.to(device) for k, v in tokens.items()}

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -186,7 +186,7 @@ class LLMPipeline(Pipeline):
                                                       'device'):
             device = self.model.model.device
         elif hasattr(self.model, 'llm_framework'):
-            device = 'cuda:0'
+            device = 'cpu'
         else:
             raise ValueError('model does not have `device` attribute!')
         return {k: v.to(device) for k, v in tokens.items()}

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -158,8 +158,8 @@ class LLMPipeline(Pipeline):
         if self.llm_framework is None:
             if hasattr(self.model, 'generate'):
                 outputs = self.model.generate(**tokens, **forward_params)
-            elif hasattr(self.model, 'model') and hasattr(self.model.model,
-                                                          'generate'):
+            elif hasattr(self.model, 'model') and hasattr(
+                    self.model.model, 'generate'):
                 outputs = self.model.model.generate(**tokens, **forward_params)
             else:
                 raise ValueError('model does not support `generate`!')

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -30,6 +30,10 @@ class LLMPipeline(Pipeline):
         if isinstance(model, str):
             logger.info(f'initiate model from {model}')
         if self._is_swift_model(model):
+            if self.llm_framework is not None:
+                logger.warning(
+                    f'Cannot using swift with llm_framework, ignoring {self.llm_framework}.'
+                )
             from swift import Swift
 
             base_model = self.cfg.safe_get('adapter_cfg.model_id_or_path')
@@ -45,9 +49,15 @@ class LLMPipeline(Pipeline):
                 trust_remote_code=True)
             swift_model = Swift.from_pretrained(base_model, model_id=model)
             return swift_model
+
         if isinstance(model, str) and is_official_hub_path(model):
             logger.info(f'initiate model from location {model}.')
-            if is_model(model):
+            if self.llm_framework is not None:
+                model_dir = model if os.path.exists(
+                    model) else snapshot_download(model)
+                return self._wrap_infer_framework(model_dir,
+                                                  self.llm_framework)
+            elif is_model(model):
                 return Model.from_pretrained(
                     model,
                     invoked_by=Invoke.PIPELINE,
@@ -83,17 +93,18 @@ class LLMPipeline(Pipeline):
         return self.cfg.safe_get('adapter_cfg.tuner_backend') == 'swift'
 
     def _wrap_infer_framework(self, model_dir, framework='vllm'):
-        if framework == 'vllm':
-            engine_args = AsyncEngineArgs.from_cli_args(args)
-            engine = AsyncLLMEngine.from_engine_args(engine_args)
+        from modelscope.pipelines.accelerate.base import InferFramework
+        return InferFramework.from_pretrained(model_dir, framework)
 
     def __init__(self,
                  format_messages: Union[Callable, str] = None,
                  format_output: Callable = None,
                  tokenizer: PreTrainedTokenizer = None,
+                 llm_framework: str = None,
                  *args,
                  **kwargs):
         self.device_map = kwargs.pop('device_map', None)
+        self.llm_framework = llm_framework
         # TODO: qwen-int4 need 'cuda'/'auto' device_map.
         if not self.device_map and 'qwen' in kwargs['model'].lower():
             self.device_map = 'cuda'

--- a/modelscope/utils/import_utils.py
+++ b/modelscope/utils/import_utils.py
@@ -275,6 +275,14 @@ def is_espnet_available(pkg_name):
         and importlib.util.find_spec('espnet')
 
 
+def is_vllm_available():
+    return importlib.util.find_spec('vllm') is not None
+
+
+def is_tensorrt_llm_available():
+    return importlib.util.find_spec('tensorrt_llm') is not None
+
+
 REQUIREMENTS_MAAPING = OrderedDict([
     ('protobuf', (is_protobuf_available, PROTOBUF_IMPORT_ERROR)),
     ('sentencepiece', (is_sentencepiece_available,


### PR DESCRIPTION
test passed:
qwen/Qwen-7B-Chat
dtype=float16
sampling params:max_new_tokens=64, do_sample=True, top_p=1.0, top_k=20, temperature=1.0
Single thread testing, so no continous batching used, only paged attention

50 inferences.
without vllm: 5.56 per request, 16557MiB
with vllm:2.07 per request, 71659MiB