### PR TITLE
修复ERes2Net说话人确认模型支持GPU推理

### DIFF
--- a/modelscope/pipelines/audio/speaker_verification_eres2net_pipeline.py
+++ b/modelscope/pipelines/audio/speaker_verification_eres2net_pipeline.py
@@ -1,6 +1,7 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
 import io
+import os
 from typing import Any, Dict, List, Union
 
 import numpy as np
@@ -49,6 +50,7 @@ class ERes2Net_Pipeline(Pipeline):
         self.config = self.model.other_config
         self.thr = self.config['yesOrno_thr']
         self.save_dict = {}
+        self.model = self.model.to(self.device)
 
     def __call__(self,
                  in_audios: Union[np.ndarray, list],
@@ -74,6 +76,7 @@ class ERes2Net_Pipeline(Pipeline):
     def forward(self, inputs: list):
         embs = []
         for x in inputs:
+            x = x.to(self.device)
             embs.append(self.model(x))
         embs = torch.cat(embs)
         return embs


### PR DESCRIPTION
修改【ERes2Net说话人确认-中文-通用-200k-Spkrs】`damo/speech_eres2net_sv_zh-cn_16k-common` 支持GPU推理，原本无法使用GPU推理，只使用CPU推理。