### PR TITLE
fix embedding and inference device in faq question answering pipeline

### DIFF
--- a/modelscope/models/nlp/structbert/faq_question_answering.py
+++ b/modelscope/models/nlp/structbert/faq_question_answering.py
@@ -375,6 +375,8 @@ class ProtoNet(nn.Module):
             input_ids = torch.IntTensor(input_ids)
         if not isinstance(input_mask, Tensor):
             input_mask = torch.IntTensor(input_mask)
+        input_ids = input_ids.to(self.bert.device)
+        input_mask = input_mask.to(self.bert.device)
         rst = self.bert(input_ids, input_mask)
         last_hidden_states = rst.last_hidden_state
         if len(input_mask.shape) == 2:

--- a/modelscope/pipelines/nlp/faq_question_answering_pipeline.py
+++ b/modelscope/pipelines/nlp/faq_question_answering_pipeline.py
@@ -50,6 +50,9 @@ class FaqQuestionAnsweringPipeline(Pipeline):
         return pipeline_parameters, pipeline_parameters, pipeline_parameters
 
     def get_sentence_embedding(self, inputs, max_len=None):
+        if (self.model or (self.has_multiple_models and self.models[0])):
+            if not self._model_prepare:
+                self.prepare_model()
         inputs = self.preprocessor.batch_encode(inputs, max_length=max_len)
         sentence_vecs = self.model.forward_sentence_embedding(inputs)
         sentence_vecs = sentence_vecs.detach().tolist()


### PR DESCRIPTION
Input and model will be on different device when get_sentence_embedding and pipeline inference are used in the same time, as described in the issue https://github.com/modelscope/modelscope/issues/671.  Add prepare model and to device in the following files:
1. modelscope/pipelines/nlp/faq_question_answering_pipeline.py
2. modelscope/models/nlp/structbert/faq_question_answering.py