### PR TITLE
fix image_portrait_enhancement_pipeline rgb channel issue

### DIFF
--- a/modelscope/pipelines/cv/image_portrait_enhancement_pipeline.py
+++ b/modelscope/pipelines/cv/image_portrait_enhancement_pipeline.py
@@ -173,11 +173,13 @@ class ImagePortraitEnhancementPipeline(Pipeline):
     def preprocess(self, input: Input) -> Dict[str, Any]:
         img = LoadImage.convert_to_ndarray(input)
 
-        img_sr = img
         if self.use_sr:
             img_sr = self.sr_process(img)
-
             img = cv2.resize(img, img_sr.shape[:2][::-1])
+            img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+        else:
+            img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+            img_sr = img.copy()
 
         result = {'img': img, 'img_sr': img_sr}
         return result
@@ -199,6 +201,9 @@ class ImagePortraitEnhancementPipeline(Pipeline):
 
             of, of_112, tfm_inv = warp_and_crop_face(
                 img, facial5points, crop_size=(self.size, self.size))
+
+            of = of[..., ::-1].copy() # BGR->RGB
+            of_112 = of_112[..., ::-1].copy() # BGR->RGB
 
             # detect orig face quality
             fq_o, fea_o = self.eqface.get_face_quality(of_112)


### PR DESCRIPTION
If image_portrait_enhancement `use_sr` flag is False, the result image will have wrong color channel.

![portrait_enhancement_result](https://github.com/modelscope/modelscope/assets/994030/78b043a3-0d75-4e8f-8622-5e2f1f9ae227)

Code example to reproduce:
```
import cv2
from modelscope.pipelines import pipeline
from modelscope.utils.constant import Tasks
from modelscope.outputs import OutputKeys

portrait_enhancement = pipeline(Tasks.image_portrait_enhancement, model='damo/cv_gpen_image-portrait-enhancement')
portrait_enhancement.use_sr = False
result = portrait_enhancement('https://ugc-img.ifengimg.com/img/2021/11/16/d8dd1b6b-2e86-4fa6-997c-d5d41203dfa6_w546_h436.jpeg')
cv2.imwrite('portrait_enhancement_result.png', result[OutputKeys.OUTPUT_IMG])

portrait_enhancement.use_sr = True
result = portrait_enhancement('https://ugc-img.ifengimg.com/img/2021/11/16/d8dd1b6b-2e86-4fa6-997c-d5d41203dfa6_w546_h436.jpeg')
cv2.imwrite('portrait_enhancement_sr_result.png', result[OutputKeys.OUTPUT_IMG])
```

I have investigated the codes of these models, and find:

- Retinaface  model needs BGR input
- realesrnet needs RGB input
- sr_process function produces BGR output
- enhance_face(GPEN) model needs RGB input

So I modified the preprocess and forward function to deal with these rgb channel order issues as follows:

```
def preprocess(self, input: Input) -> Dict[str, Any]:
    img = LoadImage.convert_to_ndarray(input)

    if self.use_sr:
        img_sr = self.sr_process(img)
        img = cv2.resize(img, img_sr.shape[:2][::-1])
        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
    else:
        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
        img_sr = img.copy()

    result = {'img': img, 'img_sr': img_sr}
    return result
```