### PR TITLE
To solve the "ImportError: always import a name 'LlamaTokenizer' from…

### DIFF
--- a/modelscope/models/nlp/llama/__init__.py
+++ b/modelscope/models/nlp/llama/__init__.py
@@ -1,8 +1,11 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 from typing import TYPE_CHECKING
 
-from transformers.models.llama import (LlamaConfig, LlamaTokenizer,
-                                       LlamaTokenizerFast)
+# from transformers.models.llama import (LlamaConfig, LlamaTokenizer,
+#                                        LlamaTokenizerFast)
+
+from transformers import LlamaTokenizer
+from transformers.models.llama import (LlamaConfig, LlamaTokenizerFast)
 
 from modelscope.utils.import_utils import LazyImportModule
 


### PR DESCRIPTION
… 'transformers. Models. Llama" problem

RuntimeError: Failed to import modelscope.models.nlp.llama2 because of the following error (look up to see its traceback): *aot imoont mame 'lamalokenizer'from tnansformers.models,llama /e:PVthoPvthn311li site-Dackagesitransformers models llama init.y