### PR TITLE
change output video format from mp4v to mp4 h264

### DIFF
--- a/modelscope/pipelines/multi_modal/text_to_video_synthesis_pipeline.py
+++ b/modelscope/pipelines/multi_modal/text_to_video_synthesis_pipeline.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 
 import cv2
 import torch
+import torchvision
 from einops import rearrange
 
 from modelscope.metainfo import Pipelines
@@ -75,14 +76,12 @@ class TextToVideoSynthesisPipeline(Pipeline):
             output_video_path = tempfile.NamedTemporaryFile(suffix='.mp4').name
             temp_video_file = True
 
-        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-        h, w, c = video[0].shape
-        video_writer = cv2.VideoWriter(
-            output_video_path, fourcc, fps=8, frameSize=(w, h))
-        for i in range(len(video)):
-            img = cv2.cvtColor(video[i], cv2.COLOR_RGB2BGR)
-            video_writer.write(img)
-        video_writer.release()
+        # Ensure video is a list of frames with shape (h, w, c)
+        frames = [torch.from_numpy(frame) for frame in video]
+        # Stack frames along a new dimension to create a 4D tensor (T, H, W, C)
+        imgs_tensor = torch.stack(frames, dim=0)
+
+        torchvision.io.write_video(output_video_path, imgs_tensor, fps=8, video_codec='h264', options={'crf': '10'})
         if temp_video_file:
             video_file_content = b''
             with open(output_video_path, 'rb') as f:


### PR DESCRIPTION
Here is Gradio's Description 
Creates a video component that can be used to upload/record videos (as an input) or display videos (as an output). For the video to be playable in the browser it must have a compatible container and codec combination. Allowed combinations are .mp4 with h264 codec, .ogg with theora codec, and .webm with vp9 codec. If the component detects that the output video would not be playable in the browser it will attempt to convert it to a playable mp4 video. If the conversion fails, the original video is returned.
I have used  text2video example code to generate output mp4 video, but failed to play on Gradio。This is my solution, and it worked.
I copied the code from https://github.com/AILab-CVC/VideoCrafter/blob/89c201c52933f5f3db7cebd46320c002dd434c0e/scripts/evaluation/funcs.py#L193