### PR TITLE
chore: Formal LICENSE content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-Copyright 2022-2023 Alibaba ModelScope. All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +187,7 @@ Copyright 2022-2023 Alibaba ModelScope. All rights reserved.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-2022 Alibaba ModelScope.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The LICENSE text is used AS IS - Need not "customized".

FWIW - I'm one of the ASF members.

https://apache.org/licenses/LICENSE-2.0#apply wrote:

> Include a copy of the Apache License, typically in a file called LICENSE, in your work

"a copy" means an identical copy.