### PR TITLE
Fix error "modelscope attributeerror: 'dict' object has no attribute …

### DIFF
--- a/modelscope/utils/input_output.py
+++ b/modelscope/utils/input_output.py
@@ -648,7 +648,7 @@ def call_pipeline_with_json(pipeline_info: PipelineInfomation,
     #     result = pipeline(**pipeline_inputs)
     # else:
     pipeline_inputs, parameters = service_base64_input_to_pipeline_input(
-        pipeline_info.task_name, body)
+        pipeline_info['task_name'], body)
     result = pipeline(pipeline_inputs, **parameters)
 
     return result


### PR DESCRIPTION
…'task_name' "

使用本地部署命令部署模型时，该错误将会导致所有推理请求报错 

如： 
```shell
modelscope server --model_id=damo/nlp_gte_sentence-embedding_chinese-large --revision=v1.1.0
```

调用 api 时，会抛出异常：
```
  File "/opt/conda/lib/python3.10/site-packages/fastapi/routing.py", line 294, in app
    raw_response = await run_endpoint_function(
  File "/opt/conda/lib/python3.10/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
  File "/opt/conda/lib/python3.10/site-packages/modelscope/server/api/routers/model_router.py", line 33, in inference
    result = call_pipeline_with_json(pipeline_info, pipeline_service,
  File "/opt/conda/lib/python3.10/site-packages/modelscope/utils/input_output.py", line 651, in call_pipeline_with_json
    pipeline_info.task_name, body)
AttributeError: 'dict' object has no attribute 'task_name'
```