### PR TITLE
exchange the order of replacement

### DIFF
--- a/modelscope/utils/plugins.py
+++ b/modelscope/utils/plugins.py
@@ -395,8 +395,7 @@ def import_module_from_model_dir(model_dir):
     ]
     create_module_from_files(relative_file_dirs, model_dir, module_name)
     for file in relative_file_dirs:
-        submodule = module_name + '.' + file.replace(os.sep, '.').replace(
-            '.py', '')
+        submodule = module_name + '.' + file.replace('.py', '').replace(os.sep, '.')
         importlib.import_module(submodule)
 
 


### PR DESCRIPTION
Here are some potential issues with the following code:

The original replacement is:
`file.replace(os.sep, '.').replace('.py', '')`

Given the file path file='venv/lib/python3.10/site-packages/regex/regex.py', 

the first replace will result in 'venv.lib.python3.10.site-packages.regex.regex.py'.

Then, the second replace will change 'lib.python3.10' to 'libthon3.10', which is not reasonable.

Therefore, I changed the order of the replacements.






