### PR TITLE
fix compatible of origin command line

### DIFF
--- a/modelscope/cli/download.py
+++ b/modelscope/cli/download.py
@@ -91,14 +91,22 @@ class DownloadCMD(CLICommand):
         parser.set_defaults(func=subparser_func)
 
     def execute(self):
-        if self.args.repo_id is not None:
-            if self.args.repo_type == 'model':
-                self.args.model = self.args.repo_id
-            elif self.args.repo_type == 'dataset':
-                self.args.dataset = self.args.repo_id
-            else:
-                raise Exception('Not support repo-type: %s'
-                                % self.args.repo_type)
+        if self.args.model or self.args.dataset:
+            # the position argument of files will be put to repo_id.
+            if self.args.repo_id is not None:
+                if self.args.files:
+                    self.args.files.insert(0, self.args.repo_id)
+                else:
+                    self.args.files = [self.args.repo_id]
+        else:
+            if self.args.repo_id is not None:
+                if self.args.repo_type == 'model':
+                    self.args.model = self.args.repo_id
+                elif self.args.repo_type == 'dataset':
+                    self.args.dataset = self.args.repo_id
+                else:
+                    raise Exception('Not support repo-type: %s'
+                                    % self.args.repo_type)
         if not self.args.model and not self.args.dataset:
             raise Exception('Model or dataset must be set.')
         if self.args.model:

--- a/tests/cli/test_download_cmd.py
+++ b/tests/cli/test_download_cmd.py
@@ -62,6 +62,11 @@ class DownloadCMDTest(unittest.TestCase):
         stat, output = subprocess.getstatusoutput(cmd)
         self.assertEqual(stat, 0)
 
+    def test_download_file(self):
+        cmd = f'python -m modelscope.cli.cli download --model {self.model_id} {download_model_file_name}'
+        stat, output = subprocess.getstatusoutput(cmd)
+        self.assertEqual(stat, 0)
+
     def test_download_with_cache(self):
         cmd = f'python -m modelscope.cli.cli download --model {self.model_id} --cache_dir {self.tmp_dir}'
         stat, output = subprocess.getstatusoutput(cmd)


### PR DESCRIPTION
Compatible with:     modelscope download --model 'AI-ModelScope/gpt2' 64.tflite