### PR TITLE
Format llm pipeline

### DIFF
--- a/modelscope/pipelines/base.py
+++ b/modelscope/pipelines/base.py
@@ -207,11 +207,15 @@ class Pipeline(ABC):
         kwargs['preprocess_params'] = preprocess_params
         kwargs['forward_params'] = forward_params
         kwargs['postprocess_params'] = postprocess_params
-        if isinstance(input, list):
-            input = {'messages': input}
 
-        print('call 2')
-        print(input)
+        # for LLMPipeline, we shall support treating list of roles as a
+        # one single 'messages' input
+        if 'LLMPipeline' in type(self).__name__ and isinstance(input, list):
+            input = {'messages': input}
+            kwargs['is_message'] = True
+
+        # print('call 2')
+        # print(input)
         if isinstance(input, list):
             if batch_size is None:
                 output = []

--- a/modelscope/pipelines/base.py
+++ b/modelscope/pipelines/base.py
@@ -197,9 +197,7 @@ class Pipeline(ABC):
 
         # simple showcase, need to support iterator type for both tensorflow and pytorch
         # input_dict = self._handle_input(input)
-        print('__call__')
-        print(input)
-        print(kwargs)
+
         # sanitize the parameters
         batch_size = kwargs.pop('batch_size', None)
         preprocess_params, forward_params, postprocess_params = self._sanitize_parameters(
@@ -214,8 +212,6 @@ class Pipeline(ABC):
             input = {'messages': input}
             kwargs['is_message'] = True
 
-        # print('call 2')
-        # print(input)
         if isinstance(input, list):
             if batch_size is None:
                 output = []

--- a/modelscope/pipelines/base.py
+++ b/modelscope/pipelines/base.py
@@ -197,7 +197,9 @@ class Pipeline(ABC):
 
         # simple showcase, need to support iterator type for both tensorflow and pytorch
         # input_dict = self._handle_input(input)
-
+        print('__call__')
+        print(input)
+        print(kwargs)
         # sanitize the parameters
         batch_size = kwargs.pop('batch_size', None)
         preprocess_params, forward_params, postprocess_params = self._sanitize_parameters(

--- a/modelscope/pipelines/base.py
+++ b/modelscope/pipelines/base.py
@@ -193,7 +193,7 @@ class Pipeline(ABC):
         # place model to cpu or gpu
         if (self.model or (self.has_multiple_models and self.models[0])):
             if not self._model_prepare:
-                self.prepare_model()
+                self.prepare_mode
 
         # simple showcase, need to support iterator type for both tensorflow and pytorch
         # input_dict = self._handle_input(input)
@@ -207,6 +207,11 @@ class Pipeline(ABC):
         kwargs['preprocess_params'] = preprocess_params
         kwargs['forward_params'] = forward_params
         kwargs['postprocess_params'] = postprocess_params
+        if isinstance(input, list):
+            input = {'messages': input}
+
+        print('call 2')
+        print(input)
         if isinstance(input, list):
             if batch_size is None:
                 output = []

--- a/modelscope/pipelines/base.py
+++ b/modelscope/pipelines/base.py
@@ -193,7 +193,7 @@ class Pipeline(ABC):
         # place model to cpu or gpu
         if (self.model or (self.has_multiple_models and self.models[0])):
             if not self._model_prepare:
-                self.prepare_mode
+                self.prepare_model()
 
         # simple showcase, need to support iterator type for both tensorflow and pytorch
         # input_dict = self._handle_input(input)

--- a/modelscope/pipelines/builder.py
+++ b/modelscope/pipelines/builder.py
@@ -110,7 +110,7 @@ def pipeline(task: str = None,
         raise ValueError('task or pipeline_name is required')
     prefer_llm_pipeline = kwargs.get('llm_first')
     if task is not None and task.lower() in [
-            Tasks.text_generation, Tasks.text2text_generation, Tasks.chat
+            Tasks.text_generation, Tasks.chat
     ]:
         # if not specified, prefer llm pipeline for aforementioned tasks
         if prefer_llm_pipeline is None:

--- a/modelscope/pipelines/builder.py
+++ b/modelscope/pipelines/builder.py
@@ -108,7 +108,7 @@ def pipeline(task: str = None,
     """
     if task is None and pipeline_name is None:
         raise ValueError('task or pipeline_name is required')
-    prefer_llm_pipeline = kwargs.get('llm_first')
+    prefer_llm_pipeline = kwargs.get('external_engine_for_llm')
     if task is not None and task.lower() in [
             Tasks.text_generation, Tasks.chat
     ]:
@@ -123,7 +123,8 @@ def pipeline(task: str = None,
     if third_party is not None:
         kwargs.pop(ThirdParty.KEY)
     if pipeline_name is None and prefer_llm_pipeline:
-        pipeline_name = llm_first_checker(model, model_revision, kwargs)
+        pipeline_name = external_engine_for_llm_checker(
+            model, model_revision, kwargs)
     else:
         model = normalize_model_input(
             model,
@@ -143,7 +144,7 @@ def pipeline(task: str = None,
                             model[0], revision=model_revision)
                 register_plugins_repo(cfg.safe_get('plugins'))
                 register_modelhub_repo(model, cfg.get('allow_remote', False))
-                pipeline_name = llm_first_checker(
+                pipeline_name = external_engine_for_llm_checker(
                     model, model_revision,
                     kwargs) if prefer_llm_pipeline else None
                 if pipeline_name is not None:
@@ -218,9 +219,10 @@ def get_default_pipeline_info(task):
     return pipeline_name, default_model
 
 
-def llm_first_checker(model: Union[str, List[str], Model,
-                                   List[Model]], revision: Optional[str],
-                      kwargs: Dict[str, Any]) -> Optional[str]:
+def external_engine_for_llm_checker(model: Union[str, List[str], Model,
+                                                 List[Model]],
+                                    revision: Optional[str],
+                                    kwargs: Dict[str, Any]) -> Optional[str]:
     from .nlp.llm_pipeline import ModelTypeHelper, LLMAdapterRegistry
 
     if isinstance(model, list):
@@ -239,5 +241,5 @@ def llm_first_checker(model: Union[str, List[str], Model,
 def clear_llm_info(kwargs: Dict):
     from modelscope.utils.model_type_helper import ModelTypeHelper
 
-    kwargs.pop('llm_first', None)
+    kwargs.pop('external_engine_for_llm', None)
     ModelTypeHelper.clear_cache()

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -370,6 +370,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
 
     def preprocess(self, inputs: Union[str, Dict], **kwargs):
         is_messages = kwargs.pop('is_messages')
+        print(kwargs)
         if is_messages:
             tokens = self.format_messages(inputs, self.tokenizer, **kwargs)
         else:
@@ -440,6 +441,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
         # for compatibility, also support input list, but we shall wrap it into Dict
         if isinstance(messages, list):
             messages = {'messages': messages}
+            kwargs['is_message'] = True
         for role, content in LLMPipeline._message_iter(messages):
             tokens = LLMPipeline._concat_with_special_tokens(
                 tokens, role, content, tokenizer)

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -290,9 +290,9 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
             os.remove(configuration_path)
 
     def _process_single(self, inputs, *args, **kwargs) -> Dict[str, Any]:
-        print('_process_single')
-        print(inputs)
-        print(kwargs)
+        # print('_process_single')
+        # print(inputs)
+        # print(kwargs)
         preprocess_params = kwargs.get('preprocess_params', {})
         forward_params = kwargs.get('forward_params', {})
         postprocess_params = kwargs.get('postprocess_params', {})
@@ -372,8 +372,9 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                 yield out
 
     def preprocess(self, inputs: Union[str, Dict], **kwargs):
-        is_messages = True
-        print(kwargs)
+        # is_messages = True
+        # print(kwargs)
+        is_messages = kwargs.pop('is_messages')
         if is_messages:
             tokens = self.format_messages(inputs, self.tokenizer, **kwargs)
         else:
@@ -436,15 +437,15 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
             model_dir, trust_remote_code=True)
 
     @staticmethod
-    def format_messages(messages: Union[List, Dict[str, List[Dict[str, str]]]],
+    def format_messages(messages: Dict[str, List[Dict[str, str]]],
                         tokenizer: PreTrainedTokenizer,
                         **kwargs) -> Dict[str, torch.Tensor]:
         # {"messages":[{"role": "system", "content": "You are a helpful assistant."}...]}
         tokens = []
-        # for compatibility, also support input list, but we shall wrap it into Dict
-        if isinstance(messages, list):
-            messages = {'messages': messages}
-            kwargs['is_message'] = True
+        # # for compatibility, also support input list, but we shall wrap it into Dict
+        # if isinstance(messages, list):
+        #     messages = {'messages': messages}
+        #     kwargs['is_message'] = True
         for role, content in LLMPipeline._message_iter(messages):
             tokens = LLMPipeline._concat_with_special_tokens(
                 tokens, role, content, tokenizer)

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -290,6 +290,9 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
             os.remove(configuration_path)
 
     def _process_single(self, inputs, *args, **kwargs) -> Dict[str, Any]:
+        print('_process_single')
+        print(inputs)
+        print(kwargs)
         preprocess_params = kwargs.get('preprocess_params', {})
         forward_params = kwargs.get('forward_params', {})
         postprocess_params = kwargs.get('postprocess_params', {})
@@ -369,7 +372,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                 yield out
 
     def preprocess(self, inputs: Union[str, Dict], **kwargs):
-        is_messages = kwargs.pop('is_messages')
+        is_messages = True
         print(kwargs)
         if is_messages:
             tokens = self.format_messages(inputs, self.tokenizer, **kwargs)

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -90,7 +90,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
         if self._is_swift_model(model):
             if self.llm_framework is not None:
                 logger.warning(
-                    f'Cannot swift with llm_framework, ignoring {self.llm_framework}.'
+                    f'Cannot use swift with llm_framework, ignoring {self.llm_framework}.'
                 )
 
             base_model = self.cfg.safe_get('adapter_cfg.model_id_or_path')
@@ -227,9 +227,6 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                                                                       str]]]],
                             tokenizer: PreTrainedTokenizer,
                             **kwargs) -> Dict[str, torch.Tensor]:
-            # for compatibility, also support input list, but we shall wrap it into Dict
-            if isinstance(messages, list):
-                messages = {'messages': messages}
             inputs, _ = self.template.encode(get_example(messages))
             inputs.pop('labels', None)
             if 'input_ids' in inputs:
@@ -441,6 +438,9 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                         **kwargs) -> Dict[str, torch.Tensor]:
         # {"messages":[{"role": "system", "content": "You are a helpful assistant."}...]}
         tokens = []
+        # for compatibility, also support input list, but we shall wrap it into Dict
+        if isinstance(messages, list):
+            messages = {'messages': messages}
         for role, content in LLMPipeline._message_iter(messages):
             tokens = LLMPipeline._concat_with_special_tokens(
                 tokens, role, content, tokenizer)

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -262,7 +262,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                 return dict(system=system, prompt=prompt, history=history)
 
         assert model_id in SWIFT_MODEL_ID_MAPPING,\
-            f'Invalid model id {model_id} or Swift framework does support not this model.'
+            f'Invalid model id {model_id} or Swift framework does not support this model.'
         args = InferArguments(model_type=SWIFT_MODEL_ID_MAPPING[model_id])
         model, template = prepare_model_template(
             args, device_map=self.device_map)

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -290,9 +290,6 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
             os.remove(configuration_path)
 
     def _process_single(self, inputs, *args, **kwargs) -> Dict[str, Any]:
-        # print('_process_single')
-        # print(inputs)
-        # print(kwargs)
         preprocess_params = kwargs.get('preprocess_params', {})
         forward_params = kwargs.get('forward_params', {})
         postprocess_params = kwargs.get('postprocess_params', {})
@@ -372,8 +369,6 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                 yield out
 
     def preprocess(self, inputs: Union[str, Dict], **kwargs):
-        # is_messages = True
-        # print(kwargs)
         is_messages = kwargs.pop('is_messages')
         if is_messages:
             tokens = self.format_messages(inputs, self.tokenizer, **kwargs)
@@ -442,10 +437,6 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                         **kwargs) -> Dict[str, torch.Tensor]:
         # {"messages":[{"role": "system", "content": "You are a helpful assistant."}...]}
         tokens = []
-        # # for compatibility, also support input list, but we shall wrap it into Dict
-        # if isinstance(messages, list):
-        #     messages = {'messages': messages}
-        #     kwargs['is_message'] = True
         for role, content in LLMPipeline._message_iter(messages):
             tokens = LLMPipeline._concat_with_special_tokens(
                 tokens, role, content, tokenizer)

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -262,7 +262,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                 return dict(system=system, prompt=prompt, history=history)
 
         assert model_id in SWIFT_MODEL_ID_MAPPING,\
-            f'Invalid model id {model_id} or Swift framework does not this model.'
+            f'Invalid model id {model_id} or Swift framework does support not this model.'
         args = InferArguments(model_type=SWIFT_MODEL_ID_MAPPING[model_id])
         model, template = prepare_model_template(
             args, device_map=self.device_map)

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -223,8 +223,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
                 for k, v in MODEL_MAPPING.items()
             }
 
-        def format_messages(messages: Union[List, Dict[str, List[Dict[str,
-                                                                      str]]]],
+        def format_messages(messages: Dict[str, List[Dict[str, str]]],
                             tokenizer: PreTrainedTokenizer,
                             **kwargs) -> Dict[str, torch.Tensor]:
             inputs, _ = self.template.encode(get_example(messages))
@@ -433,7 +432,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
             model_dir, trust_remote_code=True)
 
     @staticmethod
-    def format_messages(messages: Dict[str, List[Dict[str, str]]],
+    def format_messages(messages: Union[List, Dict[str, List[Dict[str, str]]]],
                         tokenizer: PreTrainedTokenizer,
                         **kwargs) -> Dict[str, torch.Tensor]:
         # {"messages":[{"role": "system", "content": "You are a helpful assistant."}...]}

--- a/modelscope/server/api_server.py
+++ b/modelscope/server/api_server.py
@@ -10,7 +10,7 @@ def add_server_args(parser: argparse.ArgumentParser):
     parser.add_argument('--port', type=int, default=8000, help='Server port')
     parser.add_argument('--debug', default='debug', help='Set debug level.')
     parser.add_argument(
-        '--llm_first',
+        '--external_engine_for_llm',
         type=bool,
         default=True,
         help='Use LLMPipeline first for llm models.')

--- a/modelscope/server/core/event_handlers.py
+++ b/modelscope/server/core/event_handlers.py
@@ -14,9 +14,9 @@ logger = get_logger()
 
 def _startup_model(app: FastAPI) -> None:
     logger.info('download model and create pipeline')
-    app.state.pipeline = create_pipeline(app.state.args.model_id,
-                                         app.state.args.revision,
-                                         app.state.args.llm_first)
+    app.state.pipeline = create_pipeline(
+        app.state.args.model_id, app.state.args.revision,
+        app.state.args.external_engine_for_llm)
     info = {}
     info['task_name'] = app.state.pipeline.group_key
     info['schema'] = get_task_schemas(app.state.pipeline.group_key)

--- a/modelscope/utils/deploy_checker.py
+++ b/modelscope/utils/deploy_checker.py
@@ -43,7 +43,7 @@ class DeployChecker:
             task=task,
             model=model_id,
             model_revision=model_revision,
-            llm_first=True)
+            external_engine_for_llm=True)
         pipeline_info = get_pipeline_information_by_pipeline(ppl)
 
         # call pipeline

--- a/modelscope/utils/input_output.py
+++ b/modelscope/utils/input_output.py
@@ -67,7 +67,9 @@ Todo:
 """
 
 
-def create_pipeline(model_id: str, revision: str, llm_first: bool = True):
+def create_pipeline(model_id: str,
+                    revision: str,
+                    external_engine_for_llm: bool = True):
     model_configuration_file = model_file_download(
         model_id=model_id,
         file_path=ModelFile.CONFIGURATION,
@@ -77,7 +79,7 @@ def create_pipeline(model_id: str, revision: str, llm_first: bool = True):
         task=cfg.task,
         model=model_id,
         model_revision=revision,
-        llm_first=llm_first)
+        external_engine_for_llm=external_engine_for_llm)
 
 
 def get_class_user_attributes(cls):

--- a/tests/json_call_test.py
+++ b/tests/json_call_test.py
@@ -39,7 +39,7 @@ class ModelJsonTest:
             task=task,
             model=model_id,
             model_revision=model_revision,
-            llm_first=True)
+            external_engine_for_llm=True)
         pipeline_info = get_pipeline_information_by_pipeline(ppl)
 
         # call pipeline

--- a/tests/pipelines/test_gpt3_text_generation.py
+++ b/tests/pipelines/test_gpt3_text_generation.py
@@ -20,13 +20,17 @@ class TextGPT3GenerationTest(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_gpt3_1_3B(self):
         pipe = pipeline(
-            Tasks.text_generation, model=self.model_id_1_3B, llm_first=False)
+            Tasks.text_generation,
+            model=self.model_id_1_3B,
+            external_engine_for_llm=False)
         print(pipe(self.input))
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_gpt3_1_3B_with_streaming(self):
         pipe = pipeline(
-            Tasks.text_generation, model=self.model_id_1_3B, llm_first=False)
+            Tasks.text_generation,
+            model=self.model_id_1_3B,
+            external_engine_for_llm=False)
         for output in pipe.stream_generate(self.input, max_length=64):
             print(output, end='\r')
         print()
@@ -34,13 +38,17 @@ class TextGPT3GenerationTest(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 2, 'skip test in current test level')
     def test_gpt3_2_7B(self):
         pipe = pipeline(
-            Tasks.text_generation, model=self.model_id_2_7B, llm_first=False)
+            Tasks.text_generation,
+            model=self.model_id_2_7B,
+            external_engine_for_llm=False)
         print(pipe(self.input))
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_gpt3_1_3B_with_args(self):
         pipe = pipeline(
-            Tasks.text_generation, model=self.model_id_1_3B, llm_first=False)
+            Tasks.text_generation,
+            model=self.model_id_1_3B,
+            external_engine_for_llm=False)
         print(pipe(self.input, top_p=0.9, temperature=0.9, max_length=32))
 
     @unittest.skip('distributed gpt3 13B, skipped')
@@ -67,7 +75,9 @@ class TextGPT3GenerationTest(unittest.TestCase):
                 |_ mp_rank_07_model_states.pt
         """
         pipe = pipeline(
-            Tasks.text_generation, model=self.model_dir_13B, llm_first=False)
+            Tasks.text_generation,
+            model=self.model_dir_13B,
+            external_engine_for_llm=False)
         print(pipe(self.input))
 
 

--- a/tests/pipelines/test_gpt3_text_generation.py
+++ b/tests/pipelines/test_gpt3_text_generation.py
@@ -19,24 +19,28 @@ class TextGPT3GenerationTest(unittest.TestCase):
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_gpt3_1_3B(self):
-        pipe = pipeline(Tasks.text_generation, model=self.model_id_1_3B)
+        pipe = pipeline(
+            Tasks.text_generation, model=self.model_id_1_3B, llm_first=False)
         print(pipe(self.input))
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_gpt3_1_3B_with_streaming(self):
-        pipe = pipeline(Tasks.text_generation, model=self.model_id_1_3B)
+        pipe = pipeline(
+            Tasks.text_generation, model=self.model_id_1_3B, llm_first=False)
         for output in pipe.stream_generate(self.input, max_length=64):
             print(output, end='\r')
         print()
 
     @unittest.skipUnless(test_level() >= 2, 'skip test in current test level')
     def test_gpt3_2_7B(self):
-        pipe = pipeline(Tasks.text_generation, model=self.model_id_2_7B)
+        pipe = pipeline(
+            Tasks.text_generation, model=self.model_id_2_7B, llm_first=False)
         print(pipe(self.input))
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_gpt3_1_3B_with_args(self):
-        pipe = pipeline(Tasks.text_generation, model=self.model_id_1_3B)
+        pipe = pipeline(
+            Tasks.text_generation, model=self.model_id_1_3B, llm_first=False)
         print(pipe(self.input, top_p=0.9, temperature=0.9, max_length=32))
 
     @unittest.skip('distributed gpt3 13B, skipped')
@@ -62,7 +66,8 @@ class TextGPT3GenerationTest(unittest.TestCase):
                 |_ mp_rank_06_model_states.pt
                 |_ mp_rank_07_model_states.pt
         """
-        pipe = pipeline(Tasks.text_generation, model=self.model_dir_13B)
+        pipe = pipeline(
+            Tasks.text_generation, model=self.model_dir_13B, llm_first=False)
         print(pipe(self.input))
 
 

--- a/tests/pipelines/test_gpt3_text_generation.py
+++ b/tests/pipelines/test_gpt3_text_generation.py
@@ -17,7 +17,7 @@ class TextGPT3GenerationTest(unittest.TestCase):
         self.model_dir_13B = snapshot_download(self.model_id_13B)
         self.input = '好的'
 
-    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    @unittest.skip('deprecated, skipped')
     def test_gpt3_1_3B(self):
         pipe = pipeline(
             Tasks.text_generation,
@@ -25,7 +25,7 @@ class TextGPT3GenerationTest(unittest.TestCase):
             external_engine_for_llm=False)
         print(pipe(self.input))
 
-    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    @unittest.skip('deprecated, skipped')
     def test_gpt3_1_3B_with_streaming(self):
         pipe = pipeline(
             Tasks.text_generation,
@@ -35,7 +35,7 @@ class TextGPT3GenerationTest(unittest.TestCase):
             print(output, end='\r')
         print()
 
-    @unittest.skipUnless(test_level() >= 2, 'skip test in current test level')
+    @unittest.skip('deprecated, skipped')
     def test_gpt3_2_7B(self):
         pipe = pipeline(
             Tasks.text_generation,
@@ -43,7 +43,7 @@ class TextGPT3GenerationTest(unittest.TestCase):
             external_engine_for_llm=False)
         print(pipe(self.input))
 
-    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    @unittest.skip('deprecated, skipped')
     def test_gpt3_1_3B_with_args(self):
         pipe = pipeline(
             Tasks.text_generation,

--- a/tests/pipelines/test_llama2_text_generation_pipeline.py
+++ b/tests/pipelines/test_llama2_text_generation_pipeline.py
@@ -24,6 +24,7 @@ class Llama2TextGenerationPipelineTest(unittest.TestCase):
                                    input,
                                    init_kwargs={},
                                    run_kwargs={}):
+        init_kwargs['external_engine_for_llm'] = False
         pipeline_ins = pipeline(task=Tasks.chat, model=model_id, **init_kwargs)
         pipeline_ins._model_prepare = True
         result = pipeline_ins(input, **run_kwargs)
@@ -36,6 +37,7 @@ class Llama2TextGenerationPipelineTest(unittest.TestCase):
             self.llama2_model_id_7B_chat_ms,
             self.llama2_input_chat_ch,
             init_kwargs={
+                'external_engine_for_llm': False,
                 'device_map': 'auto',
                 'torch_dtype': torch.float16,
                 'model_revision': 'v1.0.5',

--- a/tests/pipelines/test_llm_pipeline.py
+++ b/tests/pipelines/test_llm_pipeline.py
@@ -141,37 +141,25 @@ class LLMPipelineTest(unittest.TestCase):
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_chatglm2(self):
-        pipe = pipeline(
-            task='chat',
-            model='ZhipuAI/chatglm2-6b',
-            external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model='ZhipuAI/chatglm2-6b')
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_chatglm2int4(self):
-        pipe = pipeline(
-            task='chat',
-            model='ZhipuAI/chatglm2-6b-int4',
-            external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model='ZhipuAI/chatglm2-6b-int4')
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_chatglm232k(self):
-        pipe = pipeline(
-            task='chat',
-            model='ZhipuAI/chatglm2-6b-32k',
-            external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model='ZhipuAI/chatglm2-6b-32k')
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_chatglm3(self):
-        pipe = pipeline(
-            task='chat',
-            model='ZhipuAI/chatglm3-6b',
-            external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model='ZhipuAI/chatglm3-6b')
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -182,8 +170,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='modelscope/Llama-2-7b-ms',
             torch_dtype=torch.float16,
             device_map='auto',
-            ignore_file_pattern=[r'.+\.bin$'],
-            external_engine_for_llm=True)
+            ignore_file_pattern=[r'.+\.bin$'])
         print('messages: ', pipe(self.messages_en, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_en, **self.gen_cfg))
 
@@ -195,8 +182,7 @@ class LLMPipelineTest(unittest.TestCase):
             revision='v1.0.2',
             torch_dtype=torch.float16,
             device_map='auto',
-            ignore_file_pattern=[r'.+\.bin$'],
-            external_engine_for_llm=True)
+            ignore_file_pattern=[r'.+\.bin$'])
         print('messages: ', pipe(self.messages_en, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_en, **self.gen_cfg))
 
@@ -207,8 +193,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='AI-ModelScope/CodeLlama-7b-Instruct-hf',
             torch_dtype=torch.float16,
             device_map='auto',
-            ignore_file_pattern=[r'.+\.bin$'],
-            external_engine_for_llm=True)
+            ignore_file_pattern=[r'.+\.bin$'])
         print('messages: ', pipe(self.messages_code, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_code, **self.gen_cfg))
 
@@ -218,8 +203,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/baichuan-7B',
             device_map='auto',
-            torch_dtype=torch.float16,
-            external_engine_for_llm=True)
+            torch_dtype=torch.float16)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -229,8 +213,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/Baichuan-13B-Base',
             device_map='auto',
-            torch_dtype=torch.float16,
-            external_engine_for_llm=True)
+            torch_dtype=torch.float16)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -240,8 +223,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/Baichuan-13B-Chat',
             device_map='auto',
-            torch_dtype=torch.float16,
-            external_engine_for_llm=True)
+            torch_dtype=torch.float16)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -251,8 +233,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/Baichuan2-7B-Base',
             device_map='auto',
-            torch_dtype=torch.float16,
-            external_engine_for_llm=True)
+            torch_dtype=torch.float16)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -262,8 +243,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/Baichuan2-7B-Chat',
             device_map='auto',
-            torch_dtype=torch.float16,
-            external_engine_for_llm=True)
+            torch_dtype=torch.float16)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -273,8 +253,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/Baichuan2-7B-Chat-4bits',
             device_map='auto',
-            torch_dtype=torch.float16,
-            external_engine_for_llm=True)
+            torch_dtype=torch.float16)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -284,8 +263,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/Baichuan2-13B-Chat-4bits',
             device_map='auto',
-            torch_dtype=torch.float16,
-            external_engine_for_llm=True)
+            torch_dtype=torch.float16)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -296,8 +274,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='AI-ModelScope/WizardLM-13B-V1.2',
             device_map='auto',
             torch_dtype=torch.float16,
-            format_messages='wizardlm',
-            external_engine_for_llm=True)
+            format_messages='wizardlm')
         print('messages: ', pipe(self.messages_en, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_en, **self.gen_cfg))
 
@@ -308,8 +285,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='AI-ModelScope/WizardMath-7B-V1.0',
             device_map='auto',
             torch_dtype=torch.float16,
-            format_messages='wizardcode',
-            external_engine_for_llm=True)
+            format_messages='wizardcode')
         print('messages: ', pipe(self.message_wizard_math, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_wizard_math, **self.gen_cfg))
 
@@ -320,8 +296,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='AI-ModelScope/WizardCoder-Python-13B-V1.0',
             device_map='auto',
             torch_dtype=torch.float16,
-            format_messages='wizardcode',
-            external_engine_for_llm=True)
+            format_messages='wizardcode')
         print('messages: ', pipe(self.message_wizard_code, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_wizard_code, **self.gen_cfg))
 
@@ -337,28 +312,19 @@ class LLMPipelineTest(unittest.TestCase):
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_qwen(self):
-        pipe = pipeline(
-            task='chat',
-            model='qwen/Qwen-7B-Chat',
-            external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model='qwen/Qwen-7B-Chat')
         print('messages: ', pipe(self.messages_zh_with_system, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skip('Need optimum and auto-gptq')
     def test_qwen_int4(self):
-        pipe = pipeline(
-            task='chat',
-            model='qwen/Qwen-7B-Chat-Int4',
-            external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model='qwen/Qwen-7B-Chat-Int4')
         print('messages: ', pipe(self.messages_zh_with_system, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_qwen_vl(self):
-        pipe = pipeline(
-            task='chat',
-            model='qwen/Qwen-VL-Chat',
-            external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model='qwen/Qwen-VL-Chat')
         print('messages: ', pipe(self.messages_mm, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -368,27 +334,20 @@ class LLMPipelineTest(unittest.TestCase):
         model_type = ModelTypeHelper.get(model_id)
         assert not LLMAdapterRegistry.contains(model_type)
 
-        pipe = pipeline(
-            task='chat', model=model_id, external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model=model_id)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_qwen_stream_gemerate(self):
-        pipe = pipeline(
-            task='chat',
-            model='qwen/Qwen-7B-Chat',
-            external_engine_for_llm=True)
+        pipe = pipeline(task='chat', model='Qwen/Qwen-7B-Chat')
         for stream_output in pipe.stream_generate(self.messages_zh_with_system,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
-    def test_qwen1_5_stream_gemerate(self):
-        pipe = pipeline(
-            task='chat',
-            model='qwen/Qwen1.5-1.8B-Chat',
-            external_engine_for_llm=True)
+    def test_qwen1_5_stream_generate(self):
+        pipe = pipeline(task='chat', model='Qwen/Qwen1.5-1.8B-Chat')
         for stream_output in pipe.stream_generate(self.messages_zh_with_system,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')
@@ -398,8 +357,7 @@ class LLMPipelineTest(unittest.TestCase):
         pipe = pipeline(
             task='chat',
             model='baichuan-inc/Baichuan2-13B-Chat',
-            llm_framework='swift',
-            external_engine_for_llm=True)
+            llm_framework='swift')
         print('messages: ', pipe(self.messages_zh_with_system, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -408,8 +366,7 @@ class LLMPipelineTest(unittest.TestCase):
         pipe = pipeline(
             task='chat',
             model='baichuan-inc/Baichuan2-13B-Chat',
-            llm_framework='swift',
-            external_engine_for_llm=True)
+            llm_framework='swift')
         for stream_output in pipe.stream_generate(self.messages_zh,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')
@@ -417,20 +374,14 @@ class LLMPipelineTest(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_yi_with_swift(self):
         pipe = pipeline(
-            task='chat',
-            model='01ai/Yi-1.5-6B-Chat',
-            llm_framework='swift',
-            external_engine_for_llm=True)
+            task='chat', model='01ai/Yi-1.5-6B-Chat', llm_framework='swift')
         print('messages: ', pipe(self.messages_zh_with_system, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_yi_stream_gemerate(self):
         pipe = pipeline(
-            task='chat',
-            model='01ai/Yi-1.5-6B-Chat',
-            llm_framework='swift',
-            external_engine_for_llm=True)
+            task='chat', model='01ai/Yi-1.5-6B-Chat', llm_framework='swift')
         for stream_output in pipe.stream_generate(self.messages_zh,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')
@@ -440,8 +391,7 @@ class LLMPipelineTest(unittest.TestCase):
         pipe = pipeline(
             task='chat',
             model='Shanghai_AI_Laboratory/internlm2-1_8b',
-            llm_framework='swift',
-            external_engine_for_llm=True)
+            llm_framework='swift')
         print('messages: ', pipe(self.messages_zh_one_round, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -450,8 +400,7 @@ class LLMPipelineTest(unittest.TestCase):
         pipe = pipeline(
             task='chat',
             model='Shanghai_AI_Laboratory/internlm2-1_8b',
-            llm_framework='swift',
-            external_engine_for_llm=True)
+            llm_framework='swift')
         for stream_output in pipe.stream_generate(self.messages_zh_one_round,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')

--- a/tests/pipelines/test_llm_pipeline.py
+++ b/tests/pipelines/test_llm_pipeline.py
@@ -142,28 +142,36 @@ class LLMPipelineTest(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_chatglm2(self):
         pipe = pipeline(
-            task='chat', model='ZhipuAI/chatglm2-6b', llm_first=True)
+            task='chat',
+            model='ZhipuAI/chatglm2-6b',
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_chatglm2int4(self):
         pipe = pipeline(
-            task='chat', model='ZhipuAI/chatglm2-6b-int4', llm_first=True)
+            task='chat',
+            model='ZhipuAI/chatglm2-6b-int4',
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_chatglm232k(self):
         pipe = pipeline(
-            task='chat', model='ZhipuAI/chatglm2-6b-32k', llm_first=True)
+            task='chat',
+            model='ZhipuAI/chatglm2-6b-32k',
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_chatglm3(self):
         pipe = pipeline(
-            task='chat', model='ZhipuAI/chatglm3-6b', llm_first=True)
+            task='chat',
+            model='ZhipuAI/chatglm3-6b',
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -175,7 +183,7 @@ class LLMPipelineTest(unittest.TestCase):
             torch_dtype=torch.float16,
             device_map='auto',
             ignore_file_pattern=[r'.+\.bin$'],
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_en, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_en, **self.gen_cfg))
 
@@ -188,7 +196,7 @@ class LLMPipelineTest(unittest.TestCase):
             torch_dtype=torch.float16,
             device_map='auto',
             ignore_file_pattern=[r'.+\.bin$'],
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_en, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_en, **self.gen_cfg))
 
@@ -200,7 +208,7 @@ class LLMPipelineTest(unittest.TestCase):
             torch_dtype=torch.float16,
             device_map='auto',
             ignore_file_pattern=[r'.+\.bin$'],
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_code, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_code, **self.gen_cfg))
 
@@ -211,7 +219,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='baichuan-inc/baichuan-7B',
             device_map='auto',
             torch_dtype=torch.float16,
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -222,7 +230,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='baichuan-inc/Baichuan-13B-Base',
             device_map='auto',
             torch_dtype=torch.float16,
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -233,7 +241,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='baichuan-inc/Baichuan-13B-Chat',
             device_map='auto',
             torch_dtype=torch.float16,
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -244,7 +252,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='baichuan-inc/Baichuan2-7B-Base',
             device_map='auto',
             torch_dtype=torch.float16,
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -255,7 +263,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='baichuan-inc/Baichuan2-7B-Chat',
             device_map='auto',
             torch_dtype=torch.float16,
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -266,7 +274,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='baichuan-inc/Baichuan2-7B-Chat-4bits',
             device_map='auto',
             torch_dtype=torch.float16,
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -277,7 +285,7 @@ class LLMPipelineTest(unittest.TestCase):
             model='baichuan-inc/Baichuan2-13B-Chat-4bits',
             device_map='auto',
             torch_dtype=torch.float16,
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -289,7 +297,7 @@ class LLMPipelineTest(unittest.TestCase):
             device_map='auto',
             torch_dtype=torch.float16,
             format_messages='wizardlm',
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_en, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_en, **self.gen_cfg))
 
@@ -301,7 +309,7 @@ class LLMPipelineTest(unittest.TestCase):
             device_map='auto',
             torch_dtype=torch.float16,
             format_messages='wizardcode',
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.message_wizard_math, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_wizard_math, **self.gen_cfg))
 
@@ -313,7 +321,7 @@ class LLMPipelineTest(unittest.TestCase):
             device_map='auto',
             torch_dtype=torch.float16,
             format_messages='wizardcode',
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.message_wizard_code, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_wizard_code, **self.gen_cfg))
 
@@ -329,20 +337,28 @@ class LLMPipelineTest(unittest.TestCase):
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_qwen(self):
-        pipe = pipeline(task='chat', model='qwen/Qwen-7B-Chat', llm_first=True)
+        pipe = pipeline(
+            task='chat',
+            model='qwen/Qwen-7B-Chat',
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh_with_system, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skip('Need optimum and auto-gptq')
     def test_qwen_int4(self):
         pipe = pipeline(
-            task='chat', model='qwen/Qwen-7B-Chat-Int4', llm_first=True)
+            task='chat',
+            model='qwen/Qwen-7B-Chat-Int4',
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh_with_system, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_qwen_vl(self):
-        pipe = pipeline(task='chat', model='qwen/Qwen-VL-Chat', llm_first=True)
+        pipe = pipeline(
+            task='chat',
+            model='qwen/Qwen-VL-Chat',
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_mm, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -352,13 +368,17 @@ class LLMPipelineTest(unittest.TestCase):
         model_type = ModelTypeHelper.get(model_id)
         assert not LLMAdapterRegistry.contains(model_type)
 
-        pipe = pipeline(task='chat', model=model_id, llm_first=True)
+        pipe = pipeline(
+            task='chat', model=model_id, external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
     @unittest.skipUnless(test_level() >= 1, 'skip test in current test level')
     def test_qwen_stream_gemerate(self):
-        pipe = pipeline(task='chat', model='qwen/Qwen-7B-Chat', llm_first=True)
+        pipe = pipeline(
+            task='chat',
+            model='qwen/Qwen-7B-Chat',
+            external_engine_for_llm=True)
         for stream_output in pipe.stream_generate(self.messages_zh_with_system,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')
@@ -366,7 +386,9 @@ class LLMPipelineTest(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_qwen1_5_stream_gemerate(self):
         pipe = pipeline(
-            task='chat', model='qwen/Qwen1.5-1.8B-Chat', llm_first=True)
+            task='chat',
+            model='qwen/Qwen1.5-1.8B-Chat',
+            external_engine_for_llm=True)
         for stream_output in pipe.stream_generate(self.messages_zh_with_system,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')
@@ -377,7 +399,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/Baichuan2-13B-Chat',
             llm_framework='swift',
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh_with_system, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -387,7 +409,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='baichuan-inc/Baichuan2-13B-Chat',
             llm_framework='swift',
-            llm_first=True)
+            external_engine_for_llm=True)
         for stream_output in pipe.stream_generate(self.messages_zh,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')
@@ -398,7 +420,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='01ai/Yi-1.5-6B-Chat',
             llm_framework='swift',
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh_with_system, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -408,7 +430,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='01ai/Yi-1.5-6B-Chat',
             llm_framework='swift',
-            llm_first=True)
+            external_engine_for_llm=True)
         for stream_output in pipe.stream_generate(self.messages_zh,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')
@@ -419,7 +441,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='Shanghai_AI_Laboratory/internlm2-1_8b',
             llm_framework='swift',
-            llm_first=True)
+            external_engine_for_llm=True)
         print('messages: ', pipe(self.messages_zh_one_round, **self.gen_cfg))
         print('prompt: ', pipe(self.prompt_zh, **self.gen_cfg))
 
@@ -429,7 +451,7 @@ class LLMPipelineTest(unittest.TestCase):
             task='chat',
             model='Shanghai_AI_Laboratory/internlm2-1_8b',
             llm_framework='swift',
-            llm_first=True)
+            external_engine_for_llm=True)
         for stream_output in pipe.stream_generate(self.messages_zh_one_round,
                                                   **self.gen_cfg):
             print('messages: ', stream_output, end='\r')

--- a/tests/pipelines/test_mplug_owl_multimodal_dialogue.py
+++ b/tests/pipelines/test_mplug_owl_multimodal_dialogue.py
@@ -17,9 +17,7 @@ class MplugOwlMultimodalDialogueTest(unittest.TestCase):
         model = Model.from_pretrained(
             'damo/multi-modal_mplug_owl_multimodal-dialogue_7b')
         pipeline_multimodal_dialogue = pipeline(
-            task=Tasks.multimodal_dialogue,
-            model=model,
-            external_engine_for_llm=False)
+            task=Tasks.multimodal_dialogue, model=model)
         image = 'data/resource/portrait_input.png'
         system_prompt_1 = 'The following is a conversation between a curious human and AI assistant.'
         system_prompt_2 = "The assistant gives helpful, detailed, and polite answers to the user's questions."
@@ -41,16 +39,14 @@ class MplugOwlMultimodalDialogueTest(unittest.TestCase):
                 },
             ]
         }
-        result = pipeline_multimodal_dialogue(
-            messages, max_length=5, external_engine_for_llm=False)
+        result = pipeline_multimodal_dialogue(messages, max_length=5)
         print(result[OutputKeys.TEXT])
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_run_with_multimodal_dialogue_with_name(self):
         pipeline_multimodal_dialogue = pipeline(
             Tasks.multimodal_dialogue,
-            model='damo/multi-modal_mplug_owl_multimodal-dialogue_7b',
-            external_engine_for_llm=False)
+            model='damo/multi-modal_mplug_owl_multimodal-dialogue_7b')
         image = 'data/resource/portrait_input.png'
         system_prompt_1 = 'The following is a conversation between a curious human and AI assistant.'
         system_prompt_2 = "The assistant gives helpful, detailed, and polite answers to the user's questions."
@@ -79,8 +75,7 @@ class MplugOwlMultimodalDialogueTest(unittest.TestCase):
     def test_run_with_multimodal_dialogue_with_text(self):
         pipeline_multimodal_dialogue = pipeline(
             Tasks.multimodal_dialogue,
-            model='damo/multi-modal_mplug_owl_multimodal-dialogue_7b',
-            external_engine_for_llm=False)
+            model='damo/multi-modal_mplug_owl_multimodal-dialogue_7b')
         system_prompt_1 = 'The following is a conversation between a curious human and AI assistant.'
         system_prompt_2 = "The assistant gives helpful, detailed, and polite answers to the user's questions."
         messages = {

--- a/tests/pipelines/test_mplug_owl_multimodal_dialogue.py
+++ b/tests/pipelines/test_mplug_owl_multimodal_dialogue.py
@@ -19,7 +19,7 @@ class MplugOwlMultimodalDialogueTest(unittest.TestCase):
         pipeline_multimodal_dialogue = pipeline(
             task=Tasks.multimodal_dialogue,
             model=model,
-        )
+            external_engine_for_llm=False)
         image = 'data/resource/portrait_input.png'
         system_prompt_1 = 'The following is a conversation between a curious human and AI assistant.'
         system_prompt_2 = "The assistant gives helpful, detailed, and polite answers to the user's questions."
@@ -41,14 +41,16 @@ class MplugOwlMultimodalDialogueTest(unittest.TestCase):
                 },
             ]
         }
-        result = pipeline_multimodal_dialogue(messages, max_length=5)
+        result = pipeline_multimodal_dialogue(
+            messages, max_length=5, external_engine_for_llm=False)
         print(result[OutputKeys.TEXT])
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_run_with_multimodal_dialogue_with_name(self):
         pipeline_multimodal_dialogue = pipeline(
             Tasks.multimodal_dialogue,
-            model='damo/multi-modal_mplug_owl_multimodal-dialogue_7b')
+            model='damo/multi-modal_mplug_owl_multimodal-dialogue_7b',
+            external_engine_for_llm=False)
         image = 'data/resource/portrait_input.png'
         system_prompt_1 = 'The following is a conversation between a curious human and AI assistant.'
         system_prompt_2 = "The assistant gives helpful, detailed, and polite answers to the user's questions."
@@ -77,7 +79,8 @@ class MplugOwlMultimodalDialogueTest(unittest.TestCase):
     def test_run_with_multimodal_dialogue_with_text(self):
         pipeline_multimodal_dialogue = pipeline(
             Tasks.multimodal_dialogue,
-            model='damo/multi-modal_mplug_owl_multimodal-dialogue_7b')
+            model='damo/multi-modal_mplug_owl_multimodal-dialogue_7b',
+            external_engine_for_llm=False)
         system_prompt_1 = 'The following is a conversation between a curious human and AI assistant.'
         system_prompt_2 = "The assistant gives helpful, detailed, and polite answers to the user's questions."
         messages = {

--- a/tests/pipelines/test_text_generation.py
+++ b/tests/pipelines/test_text_generation.py
@@ -56,7 +56,10 @@ class TextGenerationTest(unittest.TestCase):
             first_sequence='sentence',
             second_sequence=None)
         pipeline_ins = pipeline(
-            task=Tasks.text_generation, model=model, preprocessor=preprocessor)
+            task=Tasks.text_generation,
+            model=model,
+            preprocessor=preprocessor,
+            llm_first=False)
         print(pipeline_ins(input))
 
     def run_pipeline_with_model_id(self,
@@ -64,6 +67,7 @@ class TextGenerationTest(unittest.TestCase):
                                    input,
                                    init_kwargs={},
                                    run_kwargs={}):
+        init_kwargs['llm_first'] = False
         pipeline_ins = pipeline(
             task=Tasks.text_generation, model=model_id, **init_kwargs)
         print(pipeline_ins(input, **run_kwargs))
@@ -73,12 +77,14 @@ class TextGenerationTest(unittest.TestCase):
                                              input,
                                              init_kwargs={},
                                              run_kwargs={}):
+        init_kwargs['llm_first'] = False
         pipeline_ins = pipeline(
             task=Tasks.text_generation, model=model_id, **init_kwargs)
 
         # set stream inputs
         assert isinstance(pipeline_ins, StreamingOutputMixin)
-        for output in pipeline_ins.stream_generate(input, **run_kwargs):
+        for output in pipeline_ins.stream_generate(
+                input, **run_kwargs, llm_first=False):
             print(output, end='\r')
         print()
 
@@ -256,7 +262,10 @@ class TextGenerationTest(unittest.TestCase):
                 cache_path, first_sequence='sentence', second_sequence=None)
             pipeline1 = TextGenerationPipeline(model, preprocessor)
             pipeline2 = pipeline(
-                Tasks.text_generation, model=model, preprocessor=preprocessor)
+                Tasks.text_generation,
+                model=model,
+                preprocessor=preprocessor,
+                llm_first=False)
             print(
                 f'pipeline1: {pipeline1(input)}\npipeline2: {pipeline2(input)}'
             )
@@ -272,14 +281,17 @@ class TextGenerationTest(unittest.TestCase):
             second_sequence=None)
         pipeline1 = TextGenerationPipeline(model, preprocessor)
         pipeline2 = pipeline(
-            Tasks.text_generation, model=model, preprocessor=preprocessor)
+            Tasks.text_generation,
+            model=model,
+            preprocessor=preprocessor,
+            llm_first=False)
         print(
             f'pipeline1: {pipeline1(self.gpt3_input)}\npipeline2: {pipeline2(self.gpt3_input)}'
         )
 
     @unittest.skipUnless(test_level() >= 2, 'skip test in current test level')
     def test_run_with_default_model(self):
-        pipeline_ins = pipeline(task=Tasks.text_generation)
+        pipeline_ins = pipeline(task=Tasks.text_generation, llm_first=False)
         print(
             pipeline_ins(
                 [self.palm_input_zh, self.palm_input_zh, self.palm_input_zh],
@@ -288,13 +300,17 @@ class TextGenerationTest(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 2, 'skip test in current test level')
     def test_bloom(self):
         pipe = pipeline(
-            task=Tasks.text_generation, model='langboat/bloom-1b4-zh')
+            task=Tasks.text_generation,
+            model='langboat/bloom-1b4-zh',
+            llm_first=False)
         print(pipe('中国的首都是'))
 
     @unittest.skipUnless(test_level() >= 2, 'skip test in current test level')
     def test_gpt_neo(self):
         pipe = pipeline(
-            task=Tasks.text_generation, model='langboat/mengzi-gpt-neo-base')
+            task=Tasks.text_generation,
+            model='langboat/mengzi-gpt-neo-base',
+            llm_first=False)
         print(
             pipe(
                 '我是',
@@ -308,7 +324,8 @@ class TextGenerationTest(unittest.TestCase):
     def test_gpt2(self):
         pipe = pipeline(
             task=Tasks.text_generation,
-            model='damo/nlp_gpt2_text-generation_english-base')
+            model='damo/nlp_gpt2_text-generation_english-base',
+            llm_first=False)
         print(pipe('My name is Teven and I am'))
 
     @unittest.skip('oom error for 7b model')

--- a/tests/pipelines/test_text_generation.py
+++ b/tests/pipelines/test_text_generation.py
@@ -59,7 +59,7 @@ class TextGenerationTest(unittest.TestCase):
             task=Tasks.text_generation,
             model=model,
             preprocessor=preprocessor,
-            llm_first=False)
+            external_engine_for_llm=False)
         print(pipeline_ins(input))
 
     def run_pipeline_with_model_id(self,
@@ -67,7 +67,7 @@ class TextGenerationTest(unittest.TestCase):
                                    input,
                                    init_kwargs={},
                                    run_kwargs={}):
-        init_kwargs['llm_first'] = False
+        init_kwargs['external_engine_for_llm'] = False
         pipeline_ins = pipeline(
             task=Tasks.text_generation, model=model_id, **init_kwargs)
         print(pipeline_ins(input, **run_kwargs))
@@ -77,14 +77,14 @@ class TextGenerationTest(unittest.TestCase):
                                              input,
                                              init_kwargs={},
                                              run_kwargs={}):
-        init_kwargs['llm_first'] = False
+        init_kwargs['external_engine_for_llm'] = False
         pipeline_ins = pipeline(
             task=Tasks.text_generation, model=model_id, **init_kwargs)
 
         # set stream inputs
         assert isinstance(pipeline_ins, StreamingOutputMixin)
         for output in pipeline_ins.stream_generate(
-                input, **run_kwargs, llm_first=False):
+                input, **run_kwargs, external_engine_for_llm=False):
             print(output, end='\r')
         print()
 
@@ -265,7 +265,7 @@ class TextGenerationTest(unittest.TestCase):
                 Tasks.text_generation,
                 model=model,
                 preprocessor=preprocessor,
-                llm_first=False)
+                external_engine_for_llm=False)
             print(
                 f'pipeline1: {pipeline1(input)}\npipeline2: {pipeline2(input)}'
             )
@@ -284,14 +284,15 @@ class TextGenerationTest(unittest.TestCase):
             Tasks.text_generation,
             model=model,
             preprocessor=preprocessor,
-            llm_first=False)
+            external_engine_for_llm=False)
         print(
             f'pipeline1: {pipeline1(self.gpt3_input)}\npipeline2: {pipeline2(self.gpt3_input)}'
         )
 
     @unittest.skipUnless(test_level() >= 2, 'skip test in current test level')
     def test_run_with_default_model(self):
-        pipeline_ins = pipeline(task=Tasks.text_generation, llm_first=False)
+        pipeline_ins = pipeline(
+            task=Tasks.text_generation, external_engine_for_llm=False)
         print(
             pipeline_ins(
                 [self.palm_input_zh, self.palm_input_zh, self.palm_input_zh],
@@ -302,7 +303,7 @@ class TextGenerationTest(unittest.TestCase):
         pipe = pipeline(
             task=Tasks.text_generation,
             model='langboat/bloom-1b4-zh',
-            llm_first=False)
+            external_engine_for_llm=False)
         print(pipe('中国的首都是'))
 
     @unittest.skipUnless(test_level() >= 2, 'skip test in current test level')
@@ -310,7 +311,7 @@ class TextGenerationTest(unittest.TestCase):
         pipe = pipeline(
             task=Tasks.text_generation,
             model='langboat/mengzi-gpt-neo-base',
-            llm_first=False)
+            external_engine_for_llm=False)
         print(
             pipe(
                 '我是',
@@ -325,7 +326,7 @@ class TextGenerationTest(unittest.TestCase):
         pipe = pipeline(
             task=Tasks.text_generation,
             model='damo/nlp_gpt2_text-generation_english-base',
-            llm_first=False)
+            external_engine_for_llm=False)
         print(pipe('My name is Teven and I am'))
 
     @unittest.skip('oom error for 7b model')


### PR DESCRIPTION
1. for text generation task, use llm pipeline by default.
2. for LLM, use swift by default.
3. fix parameter passing to swift


sample working code:

```python
import torch
from modelscope import pipeline

model_id = "LLM-Research/Llama-3.2-3B-Instruct"
pipe = pipeline(
    "text-generation",
    model=model_id,
    torch_dtype=torch.bfloat16,
    device_map="auto")

messages = [
    {"role": "system", "content": "You are a pirate chatbot who always responds in pirate speak!"},
    {"role": "user", "content": "Who are you?"},
]

outputs = pipe(
    messages,
    max_new_tokens=256,
)
print(outputs['message']['content'])
```

output:

`Yer lookin' fer a swashbucklin' chatbot, eh? Alright then, matey! I be Captain Blackbeak, the scurviest pirate bot to ever sail the Seven Seas... er, I mean, the digital seas! Me and me trusty computer be here to provide ye with all the treasure ye seek, whether it be answerin' yer questions, tellin' ye tales o' the high seas, or even helpin' ye navigate through treacherous waters o' knowledge. So hoist the colors, me hearty, and set sail fer a pirate-filled adventure with ol' Captain Blackbeak!`