### PR TITLE
Fix/daily

### DIFF
--- a/.dev_scripts/ci_container_test.sh
+++ b/.dev_scripts/ci_container_test.sh
@@ -31,6 +31,7 @@ if [ "$MODELSCOPE_SDK_DEBUG" == "True" ]; then
     python -m spacy download en_core_web_sm
     pip install faiss-gpu
     pip install healpy
+    pip install huggingface-hub==0.25.2
     # test with install
     pip install .
 else

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -33,6 +33,17 @@ SWIFT_MODEL_ID_MAPPING = {}
 SWIFT_FRAMEWORK = 'swift'
 
 
+def init_swift_model_mapping():
+    from swift.llm.utils import MODEL_MAPPING
+
+    global SWIFT_MODEL_ID_MAPPING
+    if not SWIFT_MODEL_ID_MAPPING:
+        SWIFT_MODEL_ID_MAPPING = {
+            v['model_id_or_path'].lower(): k
+            for k, v in MODEL_MAPPING.items()
+        }
+
+
 class LLMAdapterRegistry:
 
     llm_format_map = {'qwen': [None, None, None]}
@@ -216,14 +227,7 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
 
     def _init_swift(self, model_id, device) -> None:
         from swift.llm import prepare_model_template
-        from swift.llm.utils import MODEL_MAPPING, InferArguments
-
-        global SWIFT_MODEL_ID_MAPPING
-        if not SWIFT_MODEL_ID_MAPPING:
-            SWIFT_MODEL_ID_MAPPING = {
-                v['model_id_or_path']: k
-                for k, v in MODEL_MAPPING.items()
-            }
+        from swift.llm.utils import InferArguments
 
         def format_messages(messages: Dict[str, List[Dict[str, str]]],
                             tokenizer: PreTrainedTokenizer,
@@ -261,9 +265,11 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
             else:
                 return dict(system=system, prompt=prompt, history=history)
 
-        assert model_id in SWIFT_MODEL_ID_MAPPING,\
+        init_swift_model_mapping()
+
+        assert model_id.lower() in SWIFT_MODEL_ID_MAPPING,\
             f'Invalid model id {model_id} or Swift framework does not support this model.'
-        args = InferArguments(model_type=SWIFT_MODEL_ID_MAPPING[model_id])
+        args = InferArguments(model_type=SWIFT_MODEL_ID_MAPPING[model_id.lower()])
         model, template = prepare_model_template(
             args, device_map=self.device_map)
         self.model = add_stream_generate(model)

--- a/modelscope/pipelines/nlp/llm_pipeline.py
+++ b/modelscope/pipelines/nlp/llm_pipeline.py
@@ -269,7 +269,8 @@ class LLMPipeline(Pipeline, PipelineStreamingOutputMixin):
 
         assert model_id.lower() in SWIFT_MODEL_ID_MAPPING,\
             f'Invalid model id {model_id} or Swift framework does not support this model.'
-        args = InferArguments(model_type=SWIFT_MODEL_ID_MAPPING[model_id.lower()])
+        args = InferArguments(
+            model_type=SWIFT_MODEL_ID_MAPPING[model_id.lower()])
         model, template = prepare_model_template(
             args, device_map=self.device_map)
         self.model = add_stream_generate(model)

--- a/modelscope/preprocessors/nlp/fill_mask_preprocessor.py
+++ b/modelscope/preprocessors/nlp/fill_mask_preprocessor.py
@@ -213,11 +213,14 @@ class FillMaskPoNetPreprocessor(FillMaskPreprocessorBase):
             osp.join(model_dir, ModelFile.CONFIGURATION))
         self.language = self.cfg.model.get('language', 'en')
         if self.language == 'en':
-            from nltk.tokenize import sent_tokenize
             import nltk
-            nltk.download('punkt_tab')
-            # import_external_nltk_data(
-            #     osp.join(model_dir, 'nltk_data'), 'tokenizers/punkt_tab')
+            from nltk.tokenize import sent_tokenize
+            from packaging import version
+            if version.parse(nltk.__version__) >= version.parse('3.8.2'):
+                nltk.download('punkt_tab')
+            else:
+                import_external_nltk_data(
+                    osp.join(model_dir, 'nltk_data'), 'tokenizers/punkt_tab')
         elif self.language in ['zh', 'cn']:
 
             def sent_tokenize(para):

--- a/modelscope/utils/streaming_output.py
+++ b/modelscope/utils/streaming_output.py
@@ -175,7 +175,10 @@ class PretrainedModelStreamingOutputMixin(StreamingOutputMixin):
 
     @contextmanager
     def _replace_generate(self, model: PreTrainedModel) -> Generator:
-        if version.parse(transformers.__version__) >= version.parse('4.39.0'):
+        if version.parse(transformers.__version__) >= version.parse('4.43.0'):
+            greedy_search_name = 'stream_greedy_search'
+            sample_name = '_sample'
+        elif version.parse(transformers.__version__) >= version.parse('4.39.0'):
             greedy_search_name = '_greedy_search'
             sample_name = '_sample'
         else:
@@ -449,6 +452,7 @@ class PretrainedModelStreamingOutputMixin(StreamingOutputMixin):
                     break
 
             # prepare model inputs
+            model_kwargs = self._get_initial_cache_position(input_ids, model_kwargs)
             model_inputs = self.prepare_inputs_for_generation(
                 input_ids, **model_kwargs)
 

--- a/modelscope/utils/streaming_output.py
+++ b/modelscope/utils/streaming_output.py
@@ -178,7 +178,8 @@ class PretrainedModelStreamingOutputMixin(StreamingOutputMixin):
         if version.parse(transformers.__version__) >= version.parse('4.43.0'):
             greedy_search_name = 'stream_greedy_search'
             sample_name = '_sample'
-        elif version.parse(transformers.__version__) >= version.parse('4.39.0'):
+        elif version.parse(
+                transformers.__version__) >= version.parse('4.39.0'):
             greedy_search_name = '_greedy_search'
             sample_name = '_sample'
         else:
@@ -452,7 +453,8 @@ class PretrainedModelStreamingOutputMixin(StreamingOutputMixin):
                     break
 
             # prepare model inputs
-            model_kwargs = self._get_initial_cache_position(input_ids, model_kwargs)
+            model_kwargs = self._get_initial_cache_position(
+                input_ids, model_kwargs)
             model_inputs = self.prepare_inputs_for_generation(
                 input_ids, **model_kwargs)
 


### PR DESCRIPTION
问题&修复：
‒ transformers版本迭代引入的break change
  1. cache position 需要额外初始化 
  2. stream_gready_search 成员变量改名
‒ swift映射
  3. qwen-> Qwen：通过小写匹配
  4. 使用llm_pipeline时llm_framework参数需要传入；不适用时不能传入
‒ huggingface_hub版本迭代引入的break change （间接依赖）
  5. diffusers依赖该库，无法直接修改。ci&daily环境huggingface_hub版本降至0.25
‒ ci和daily的nltk环境不同
  6. 刚好一个在3.8.2以上，一个在3.8.2以下。根据当前nltk版本做不同操作。The "punkt" package consists in unsafe pickles, so it is deprecated and not used in NLTK 3.8.2. It is replaced by "punkt_tab". Users should definitively avoid the highly toxic pickle vulnerability, and upgrade to NLTK 3.8.2.