### PR TITLE
Update transformers into dependency.

### DIFF
--- a/requirements/hub.txt
+++ b/requirements/hub.txt
@@ -1,3 +1,4 @@
 requests>=2.25
 tqdm>=4.64.0
 urllib3>=1.26
+transformers


### PR DESCRIPTION
Currently, modelscope use `transformers`'s AutoTokenizer but the dependency is not in `hub.txt`. So I update it.