### PR TITLE
standardize download directory for models/datasets

### DIFF
--- a/modelscope/hub/snapshot_download.py
+++ b/modelscope/hub/snapshot_download.py
@@ -252,7 +252,7 @@ def _snapshot_download(
         if repo_type == REPO_TYPE_MODEL:
             directory = os.path.abspath(
                 local_dir) if local_dir is not None else os.path.join(
-                    system_cache, *repo_id.split('/'))
+                    system_cache, 'models', *repo_id.split('/'))
             print(f'Downloading Model to directory: {directory}')
             revision_detail = _api.get_valid_revision_detail(
                 repo_id, revision=revision, cookies=cookies)


### PR DESCRIPTION
默认
模型：
~/.cache/modelscope/hub/models/{model_owner}/{model_name}
数据集：
~/.cache/modelscope/hub/datasets/{dataset_owner}/{dataset_name}

配置MODELSCOPE_CACHE环境变量：
模型：
$MODELSCOPE_CACHE/models/{model_owner}/{model_name}
数据集：
$MODELSCOPE_CACHE/datasets/{dataset_owner}/{dataset_name}