### PR TITLE
face recognition pipline adds use_det parameter to control whether to use face detection model

### DIFF
--- a/modelscope/pipelines/cv/face_processing_base_pipeline.py
+++ b/modelscope/pipelines/cv/face_processing_base_pipeline.py
@@ -103,7 +103,7 @@ class FaceProcessingBasePipeline(Pipeline):
                 scores, bboxes, face_lmks = rtn
                 face_lmks = face_lmks.reshape(5, 2)
                 align_img, _ = align_face(img, (112, 112), face_lmks)
-    
+
                 result = {}
                 result['img'] = np.ascontiguousarray(align_img)
                 result['scores'] = [scores]

--- a/modelscope/pipelines/cv/face_processing_base_pipeline.py
+++ b/modelscope/pipelines/cv/face_processing_base_pipeline.py
@@ -22,7 +22,7 @@ logger = get_logger()
 
 class FaceProcessingBasePipeline(Pipeline):
 
-    def __init__(self, model: str, **kwargs):
+    def __init__(self, model: str, use_det=True, **kwargs):
         """
         use `model` to create a face processing pipeline and output cropped img, scores, bbox and lmks.
 
@@ -30,11 +30,13 @@ class FaceProcessingBasePipeline(Pipeline):
             model: model id on modelscope hub.
 
         """
+        self.use_det = use_det
         super().__init__(model=model, **kwargs)
         # face detect pipeline
-        det_model_id = 'damo/cv_ddsar_face-detection_iclr23-damofd'
-        self.face_detection = pipeline(
-            Tasks.face_detection, model=det_model_id)
+        if use_det:
+            det_model_id = 'damo/cv_ddsar_face-detection_iclr23-damofd'
+            self.face_detection = pipeline(
+                Tasks.face_detection, model=det_model_id)
 
     def _choose_face(self,
                      det_result,
@@ -94,21 +96,27 @@ class FaceProcessingBasePipeline(Pipeline):
     def preprocess(self, input: Input) -> Dict[str, Any]:
         img = LoadImage.convert_to_ndarray(input)
         img = img[:, :, ::-1]
-        det_result = self.face_detection(img.copy())
-        rtn = self._choose_face(det_result, img_shape=img.shape)
-        if rtn is not None:
-            scores, bboxes, face_lmks = rtn
-            face_lmks = face_lmks.reshape(5, 2)
-            align_img, _ = align_face(img, (112, 112), face_lmks)
-
-            result = {}
-            result['img'] = np.ascontiguousarray(align_img)
-            result['scores'] = [scores]
-            result['bbox'] = bboxes
-            result['lmks'] = face_lmks
-            return result
+        if self.use_det:
+            det_result = self.face_detection(img.copy())
+            rtn = self._choose_face(det_result, img_shape=img.shape)
+            if rtn is not None:
+                scores, bboxes, face_lmks = rtn
+                face_lmks = face_lmks.reshape(5, 2)
+                align_img, _ = align_face(img, (112, 112), face_lmks)
+    
+                result = {}
+                result['img'] = np.ascontiguousarray(align_img)
+                result['scores'] = [scores]
+                result['bbox'] = bboxes
+                result['lmks'] = face_lmks
+                return result
+            else:
+                return None
         else:
-            return None
+            result = {}
+            resized_img = cv2.resize(img, (112, 112))
+            result['img'] = np.ascontiguousarray(resized_img)
+            return result
 
     def align_face_padding(self, img, rect, padding_size=16, pad_pixel=127):
         rect = np.reshape(rect, (-1, 4))

--- a/modelscope/pipelines/cv/face_recognition_pipeline.py
+++ b/modelscope/pipelines/cv/face_recognition_pipeline.py
@@ -17,7 +17,7 @@ from modelscope.pipelines.builder import PIPELINES
 from modelscope.preprocessors import LoadImage
 from modelscope.utils.constant import ModelFile, Tasks
 from modelscope.utils.logger import get_logger
-from . import FaceProcessingBasePipeline
+from modelscope.pipelines.cv.face_processing_base_pipeline import FaceProcessingBasePipeline
 
 logger = get_logger()
 
@@ -26,15 +26,14 @@ logger = get_logger()
     Tasks.face_recognition, module_name=Pipelines.face_recognition)
 class FaceRecognitionPipeline(FaceProcessingBasePipeline):
 
-    def __init__(self, model: str, **kwargs):
+    def __init__(self, model: str, use_det=True, **kwargs):
         """
         use `model` to create a face recognition pipeline for prediction
         Args:
             model: model id on modelscope hub.
         """
-
         # face recong model
-        super().__init__(model=model, **kwargs)
+        super().__init__(model=model, use_det=use_det, **kwargs)
         device = torch.device(
             f'cuda:{0}' if torch.cuda.is_available() else 'cpu')
         self.device = device

--- a/modelscope/pipelines/cv/face_recognition_pipeline.py
+++ b/modelscope/pipelines/cv/face_recognition_pipeline.py
@@ -14,10 +14,11 @@ from modelscope.outputs import OutputKeys
 from modelscope.pipelines import pipeline
 from modelscope.pipelines.base import Input, Pipeline
 from modelscope.pipelines.builder import PIPELINES
+from modelscope.pipelines.cv.face_processing_base_pipeline import \
+    FaceProcessingBasePipeline
 from modelscope.preprocessors import LoadImage
 from modelscope.utils.constant import ModelFile, Tasks
 from modelscope.utils.logger import get_logger
-from modelscope.pipelines.cv.face_processing_base_pipeline import FaceProcessingBasePipeline
 
 logger = get_logger()
 

--- a/tests/pipelines/test_face_recognition.py
+++ b/tests/pipelines/test_face_recognition.py
@@ -17,11 +17,35 @@ class FaceRecognitionTest(unittest.TestCase):
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_face_compare(self):
-        img1 = 'data/test/images/face_recognition_1.png'
-        img2 = 'data/test/images/face_recognition_2.png'
+        img1 = 'https://modelscope.oss-cn-beijing.aliyuncs.com/test/images/face_recognition_1.png'
+        img2 = 'https://modelscope.oss-cn-beijing.aliyuncs.com/test/images/face_recognition_2.png'
 
         face_recognition = pipeline(
             Tasks.face_recognition, model=self.model_id)
+        emb1 = face_recognition(img1)[OutputKeys.IMG_EMBEDDING]
+        emb2 = face_recognition(img2)[OutputKeys.IMG_EMBEDDING]
+        sim = np.dot(emb1[0], emb2[0])
+        print(f'Cos similarity={sim:.3f}, img1:{img1}  img2:{img2}')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_face_compare_use_det(self):
+        img1 = 'https://modelscope.oss-cn-beijing.aliyuncs.com/test/images/face_recognition_1.png'
+        img2 = 'https://modelscope.oss-cn-beijing.aliyuncs.com/test/images/face_recognition_2.png'
+
+        face_recognition = pipeline(
+            Tasks.face_recognition, model=self.model_id, use_det=True)
+        emb1 = face_recognition(img1)[OutputKeys.IMG_EMBEDDING]
+        emb2 = face_recognition(img2)[OutputKeys.IMG_EMBEDDING]
+        sim = np.dot(emb1[0], emb2[0])
+        print(f'Cos similarity={sim:.3f}, img1:{img1}  img2:{img2}')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_face_compare_not_use_det(self):
+        img1 = 'https://modelscope.oss-cn-beijing.aliyuncs.com/test/images/face_recognition_1.png'
+        img2 = 'https://modelscope.oss-cn-beijing.aliyuncs.com/test/images/face_recognition_2.png'
+
+        face_recognition = pipeline(
+            Tasks.face_recognition, model=self.model_id, use_det=False)
         emb1 = face_recognition(img1)[OutputKeys.IMG_EMBEDDING]
         emb2 = face_recognition(img2)[OutputKeys.IMG_EMBEDDING]
         sim = np.dot(emb1[0], emb2[0])


### PR DESCRIPTION
人脸识别pipline，默认输入会先经过人脸检测模型截取最大的人脸框，再经过人脸识别模型。业务场景需要直接计算输入图像的人脸特征向量，新增use_det参数，可以减少计算量和显存占用，并防止检测模型检测不到人脸时报错。