### PR TITLE
feat ollama template: 7 new templates

### DIFF
--- a/tests/tools/test_to_ollama.py
+++ b/tests/tools/test_to_ollama.py
@@ -123,6 +123,36 @@ class TestToOllama(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_check_template_type(self):
         _test_check_tmpl_type(
+            'DevQuasar/CohereForAI.c4ai-command-r7b-arabic-02-2025-GGUF',
+            'command-r7b-arabic',
+            gguf_meta={
+                'general.name': 'CohereForAI.c4ai Command R7B Arabic 02 2025'
+            })
+        _test_check_tmpl_type(
+            'lmstudio-community/granite-vision-3.2-2b-GGUF',
+            'granite3.2-vision',
+            gguf_meta={'general.name': 'Granite Vision 3.2 2b'})
+        _test_check_tmpl_type(
+            'unsloth/Phi-4-mini-instruct-GGUF',
+            'phi4-mini',
+            gguf_meta={'general.name': 'Phi 4 Mini Instruct'})
+        _test_check_tmpl_type(
+            'lmstudio-community/granite-3.2-2b-instruct-GGUF',
+            'granite3.2',
+            gguf_meta={'general.name': 'Granite 3.2 2b Instruct'})
+        _test_check_tmpl_type(
+            'unsloth/r1-1776-GGUF',
+            'r1-1776',
+            gguf_meta={'general.name': 'R1 1776'})
+        _test_check_tmpl_type(
+            'QuantFactory/DeepScaleR-1.5B-Preview-GGUF',
+            'deepscaler',
+            gguf_meta={'general.name': 'DeepScaleR 1.5B Preview'})
+        _test_check_tmpl_type(
+            'lmstudio-community/OpenThinker-32B-GGUF',
+            'openthinker',
+            gguf_meta={'general.name': 'Qwen2.5 7B Instruct'})
+        _test_check_tmpl_type(
             'LLM-Research/Llama-3.3-70B-Instruct',
             'llama3.3',
             gguf_meta={'general.name': 'Llama 3.3 70B Instruct'})


### PR DESCRIPTION
1. 新增command-r7b-arabic、granite3.2-vision、phi4-mini、granite3.2、r1-1776、deepscaler、openthinker template支持
2. 新增TemplateInfo配置 allow_general_name，以解决openthinker两个gguf repo 文件header的general.name都被错误配置为qwen2.5的问题：openthinker的allow_general_name配置为false，后续该类模型不根据general.name进行类型判断，仅根据model_id；其他默认为true，优先使用general.name判断。
（已验证openthinker使用qwen2.5的模版不思考，不终止。使用openthinker的template正常）
![image](https://github.com/user-attachments/assets/6fde9e2a-37e9-4364-b49a-091e33eea6c5)

