### PR TITLE
[Feature] Add scan_cache_dir function

### DIFF
--- a/modelscope/cli/cli.py
+++ b/modelscope/cli/cli.py
@@ -10,6 +10,7 @@ from modelscope.cli.login import LoginCMD
 from modelscope.cli.modelcard import ModelCardCMD
 from modelscope.cli.pipeline import PipelineCMD
 from modelscope.cli.plugins import PluginsCMD
+from modelscope.cli.scancache import ScanCacheCMD
 from modelscope.cli.server import ServerCMD
 from modelscope.cli.upload import UploadCMD
 from modelscope.hub.api import HubApi
@@ -34,6 +35,7 @@ def run_cmd():
     ServerCMD.define_args(subparsers)
     LoginCMD.define_args(subparsers)
     LlamafileCMD.define_args(subparsers)
+    ScanCacheCMD.define_args(subparsers)
 
     args = parser.parse_args()
 

--- a/modelscope/cli/scancache.py
+++ b/modelscope/cli/scancache.py
@@ -1,0 +1,64 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+import logging
+import os
+import time
+from argparse import ArgumentParser
+from typing import Optional
+
+from modelscope.cli.base import CLICommand
+from modelscope.hub.cache_manager import scan_cache_dir
+from modelscope.hub.errors import CacheNotFound
+from modelscope.utils.logger import get_logger
+
+logger = get_logger(log_level=logging.WARNING)
+
+current_path = os.path.dirname(os.path.abspath(__file__))
+
+
+def subparser_func(args):
+    """ Function which will be called for a specific sub parser.
+    """
+    return ScanCacheCMD(args)
+
+
+class ScanCacheCMD(CLICommand):
+    name = 'scan-cache'
+
+    def __init__(self, args):
+        self.args = args
+        self.cache_dir: Optional[str] = args.dir
+
+    @staticmethod
+    def define_args(parsers: ArgumentParser):
+        """ define args for create pipeline template command.
+        """
+        parser = parsers.add_parser(ScanCacheCMD.name)
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            '--dir',
+            type=str,
+            default=None,
+            help=
+            'cache directory to scan (optional). Default to the default ModelScope cache.',
+        )
+
+        parser.set_defaults(func=subparser_func)
+
+    def execute(self):
+        try:
+            t0 = time.time()
+            cache_info = scan_cache_dir(self.cache_dir)
+            t1 = time.time()
+        except CacheNotFound as exc:
+            cache_dir = exc.cache_dir
+            print(f'Cache directory not found: {cache_dir}')
+            return
+        print(cache_info.export_as_table())
+        print(
+            f'\nDone in {round(t1 - t0, 1)}s. Scanned {len(cache_info.repos)} repo(s)'
+            f' for a total of {cache_info.size_on_disk_str}.')
+        if len(cache_info.warnings) > 0:
+            message = f'Got {len(cache_info.warnings)} warning(s) while scanning.'
+            print(message)
+            for warning in cache_info.warnings:
+                print(warning)

--- a/modelscope/hub/cache_manager.py
+++ b/modelscope/hub/cache_manager.py
@@ -1,0 +1,595 @@
+"""Contains utilities to manage the ModelScope cache directory."""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, FrozenSet, List, Literal, Optional, Set, Union
+
+from modelscope.hub.errors import CacheNotFound, CorruptedCacheException
+from modelscope.hub.utils.caching import ModelFileSystemCache
+from modelscope.utils.constant import REPO_TYPE_DATASET, REPO_TYPE_MODEL
+from modelscope.utils.file_utils import get_default_modelscope_cache_dir
+from modelscope.utils.logger import get_logger
+from .utils.utils import convert_readable_size, format_timesince, tabulate
+
+logger = get_logger()
+
+# List of OS-created helper files that need to be ignored
+FILES_TO_IGNORE = ['.DS_Store', '._____temp']
+
+
+@dataclass(frozen=True)
+class CachedFileInfo:
+    """Frozen data structure holding information about a single cached file.
+
+    Args:
+        file_name (`str`):
+            Name of the file. Example: `config.json`.
+        file_path (`Path`):
+            Path of the file in the `snapshots` directory. The file path is a symlink
+            referring to a blob in the `blobs` folder.
+        blob_path (`Path`):
+            Path of the blob file. This is equivalent to `file_path.resolve()`.
+        size_on_disk (`int`):
+            Size of the blob file in bytes.
+        blob_last_accessed (`float`):
+            Timestamp of the last time the blob file has been accessed (from any
+            revision).
+        blob_last_modified (`float`):
+            Timestamp of the last time the blob file has been modified/created.
+    """
+
+    file_name: str
+    file_path: Path
+    blob_path: Path
+    size_on_disk: int
+
+    blob_last_accessed: float
+    blob_last_modified: float
+
+    @property
+    def blob_last_accessed_str(self) -> str:
+        """
+        (property) Timestamp of the last time the blob file has been accessed (from any
+        revision), returned as a human-readable string.
+
+        Example: "2 weeks ago".
+        """
+        return format_timesince(self.blob_last_accessed)
+
+    @property
+    def blob_last_modified_str(self) -> str:
+        """
+        (property) Timestamp of the last time the blob file has been modified, returned
+        as a human-readable string.
+
+        Example: "2 weeks ago".
+        """
+        return format_timesince(self.blob_last_modified)
+
+    @property
+    def size_on_disk_str(self) -> str:
+        """
+        (property) Size of the blob file as a human-readable string.
+
+        Example: "42.2K".
+        """
+        return convert_readable_size(self.size_on_disk)
+
+
+@dataclass(frozen=True)
+class CachedRevisionInfo:
+    """Frozen data structure holding information about a revision.
+
+    Args:
+        commit_hash (`str`):
+            Hash of the revision (unique).
+            Example: `"9338f7b671827df886678df2bdd7cc7b4f36dffd"`.
+        snapshot_path (`Path`):
+            Path to the revision directory in the `snapshots` folder. It contains the
+            exact tree structure as the repo on the Hub.
+        files: (`FrozenSet[CachedFileInfo]`):
+            Set of [`~CachedFileInfo`] describing all files contained in the snapshot.
+        refs (`FrozenSet[str]`):
+            Set of `refs` pointing to this revision. If the revision has no `refs`, it
+            is considered detached.
+            Example: `{"main", "2.4.0"}` or `{"refs/pr/1"}`.
+        size_on_disk (`int`):
+            Sum of the blob file sizes that are symlink-ed by the revision.
+        last_modified (`float`):
+            Timestamp of the last time the revision has been created/modified.
+    """
+
+    commit_hash: str
+    snapshot_path: Path
+    size_on_disk: int
+    files: FrozenSet[CachedFileInfo]
+    refs: FrozenSet[str]
+
+    last_modified: float
+
+    @property
+    def last_modified_str(self) -> str:
+        """
+        (property) Timestamp of the last time the revision has been modified, returned
+        as a human-readable string.
+
+        Example: "2 weeks ago".
+        """
+        return format_timesince(self.last_modified)
+
+    @property
+    def size_on_disk_str(self) -> str:
+        """
+        (property) Sum of the blob file sizes as a human-readable string.
+
+        Example: "42.2K".
+        """
+        return convert_readable_size(self.size_on_disk)
+
+    @property
+    def nb_files(self) -> int:
+        """
+        (property) Total number of files in the revision.
+        """
+        return len(self.files)
+
+
+@dataclass(frozen=True)
+class CachedRepoInfo:
+    """Frozen data structure holding information about a cached repository.
+
+    Args:
+        repo_id (`str`):
+            Repo id of the repo on the Hub. Example: `"damo/bert-base-chinese"`.
+        repo_type (`Literal["dataset", "model"]`):
+            Type of the cached repo.
+        repo_path (`Path`):
+            Local path to the cached repo.
+        size_on_disk (`int`):
+            Sum of the blob file sizes in the cached repo.
+        nb_files (`int`):
+            Total number of blob files in the cached repo.
+        revisions (`FrozenSet[CachedRevisionInfo]`):
+            Set of [`~CachedRevisionInfo`] describing all revisions cached in the repo.
+        last_accessed (`float`):
+            Timestamp of the last time a blob file of the repo has been accessed.
+        last_modified (`float`):
+            Timestamp of the last time a blob file of the repo has been modified/created.
+    """
+
+    repo_id: str
+    repo_type: str
+    repo_path: Path
+    size_on_disk: int
+    nb_files: int
+    revisions: FrozenSet[CachedRevisionInfo]
+
+    last_accessed: float
+    last_modified: float
+
+    @property
+    def last_accessed_str(self) -> str:
+        """
+        (property) Last time a blob file of the repo has been accessed, returned as a
+        human-readable string.
+
+        Example: "2 weeks ago".
+        """
+        return format_timesince(self.last_accessed)
+
+    @property
+    def last_modified_str(self) -> str:
+        """
+        (property) Last time a blob file of the repo has been modified, returned as a
+        human-readable string.
+
+        Example: "2 weeks ago".
+        """
+        return format_timesince(self.last_modified)
+
+    @property
+    def size_on_disk_str(self) -> str:
+        """
+        (property) Sum of the blob file sizes as a human-readable string.
+
+        Example: "42.2K".
+        """
+        return convert_readable_size(self.size_on_disk)
+
+    @property
+    def refs(self) -> Dict[str, CachedRevisionInfo]:
+        """
+        (property) Mapping between `refs` and revision data structures.
+        """
+        return {
+            ref: revision
+            for revision in self.revisions for ref in revision.refs
+        }
+
+
+@dataclass(frozen=True)
+class ModelScopeCacheInfo:
+    """Frozen data structure holding information about the entire cache-system.
+
+    This data structure is returned by [`scan_cache_dir`] and is immutable.
+
+    Args:
+        size_on_disk (`int`):
+            Sum of all valid repo sizes in the cache-system.
+        repos (`FrozenSet[CachedRepoInfo]`):
+            Set of [`~CachedRepoInfo`] describing all valid cached repos found on the
+            cache-system while scanning.
+        warnings (`List[CorruptedCacheException]`):
+            List of [`~CorruptedCacheException`] that occurred while scanning the cache.
+            Those exceptions are captured so that the scan can continue. Corrupted repos
+            are skipped from the scan.
+    """
+
+    size_on_disk: int
+    repos: FrozenSet[CachedRepoInfo]
+    warnings: List[CorruptedCacheException]
+
+    @property
+    def size_on_disk_str(self) -> str:
+        """
+        (property) Sum of all valid repo sizes in the cache-system as a human-readable
+        string.
+        """
+        return convert_readable_size(self.size_on_disk)
+
+    def export_as_table(self) -> str:
+        """Generate a detailed table from the [`ModelScopeCacheInfo`] object.
+
+        Returns a table with a row per repo and revision (thus multiple rows can appear for a single repo), with columns
+        "repo_id", "repo_type", "revision", "size_on_disk", "nb_files", "last_modified", "refs", "local_path".
+
+        Example:
+        ```py
+        >>> from modelscope.hub.utils import scan_cache_dir
+
+        >>> ms_cache_info = scan_cache_dir()
+        ModelScopeCacheInfo(...)
+
+        >>> print(ms_cache_info.export_as_table())
+        REPO ID                                             REPO TYPE REVISION                                      SIZE ON DISK NB FILES LAST_MODIFIED REFS LOCAL PATH
+        --------------------------------------------------- --------- -------------------------------------------- ------------ -------- ------------- ---- -------------------------------------------------------------
+        damo/bert-base-chinese                              model     9338f7b671827df886678df2bdd7cc7b4f36dffd             2.7M        5 1 week ago    main ~/.cache/modelscope/hub/models--damo--bert-base-chinese/...
+        damo/structured-bert                                model     76f64c2173c6ff1941f5ca08a23fa36611276874             8.8K        1 1 week ago    main ~/.cache/modelscope/hub/models--damo--structured-bert/...
+        damo/t5-base                                        model     d78aea13fa7ecd06c29e3e46195d6341255065d5           893.8M        4 7 months ago  main ~/.cache/modelscope/hub/models--damo--t5-base/...
+        ```
+
+        Returns:
+            `str`: The table as a string.
+        """  # noqa: E501
+
+        def format_repo_revision(repo: CachedRepoInfo,
+                                 revision: CachedRevisionInfo) -> List[str]:
+            """Format a single repo and revision into a list of strings for tabulation."""
+            return [
+                repo.repo_id,
+                repo.repo_type,
+                revision.commit_hash,
+                '{:>12}'.format(revision.size_on_disk_str),
+                revision.nb_files,
+                revision.last_modified_str,
+                ', '.join(sorted(revision.refs)),
+                str(revision.snapshot_path),
+            ]
+
+        column_headers = [
+            'REPO ID',
+            'REPO TYPE',
+            'REVISION',
+            'SIZE ON DISK',
+            'NB FILES',
+            'LAST_MODIFIED',
+            'REFS',
+            'LOCAL PATH',
+        ]
+
+        table_data = [
+            format_repo_revision(repo, revision)
+            for repo in sorted(self.repos, key=lambda repo: repo.repo_path)
+            for revision in sorted(
+                repo.revisions, key=lambda revision: revision.commit_hash)
+        ]
+
+        return tabulate(
+            rows=table_data,
+            headers=column_headers,
+        )
+
+
+def scan_cache_dir(
+        cache_dir: Optional[Union[str, Path]] = None) -> ModelScopeCacheInfo:
+    """Scan the entire ModelScope cache-system and return a [`ModelScopeCacheInfo`] structure.
+
+    Use `scan_cache_dir` to programmatically scan your cache-system. The cache
+    will be scanned repo by repo. If a repo is corrupted, a [`~CorruptedCacheException`]
+    will be thrown internally but captured and returned in the [`~ModelScopeCacheInfo`]
+    structure. Only valid repos get a proper report.
+
+    ```py
+    >>> from modelscope.hub.utils import scan_cache_dir
+
+    >>> ms_cache_info = scan_cache_dir()
+    ModelScopeCacheInfo(
+        size_on_disk=3398085269,
+        repos=frozenset({
+            CachedRepoInfo(
+                repo_id='damo/t5-small',
+                repo_type='model',
+                repo_path=PosixPath(...),
+                size_on_disk=970726914,
+                nb_files=11,
+                revisions=frozenset({
+                    CachedRevisionInfo(
+                        commit_hash='d78aea13fa7ecd06c29e3e46195d6341255065d5',
+                        size_on_disk=970726339,
+                        snapshot_path=PosixPath(...),
+                        files=frozenset({
+                            CachedFileInfo(
+                                file_name='config.json',
+                                size_on_disk=1197
+                                file_path=PosixPath(...),
+                                blob_path=PosixPath(...),
+                            ),
+                            CachedFileInfo(...),
+                            ...
+                        }),
+                    ),
+                    CachedRevisionInfo(...),
+                    ...
+                }),
+            ),
+            CachedRepoInfo(...),
+            ...
+        }),
+        warnings=[
+            CorruptedCacheException("Snapshots dir doesn't exist in cached repo: ..."),
+            CorruptedCacheException(...),
+            ...
+        ],
+    )
+    ```
+
+    Args:
+        cache_dir (`str` or `Path`, `optional`):
+            Cache directory to scan. Defaults to the default ModelScope cache directory.
+
+    Raises:
+        `CacheNotFound`: If the cache directory does not exist.
+        `ValueError`: If the cache directory is a file, instead of a directory.
+
+    Returns: a [`ModelScopeCacheInfo`] object.
+    """
+    if cache_dir is None:
+        cache_dir = get_default_modelscope_cache_dir()
+
+    cache_dir = Path(cache_dir).expanduser().resolve()
+    if not cache_dir.exists():
+        raise CacheNotFound(
+            f'Cache directory not found: {cache_dir}. Please use `cache_dir` argument or set `MODELSCOPE_CACHE` environment variable.',  # noqa: E501
+            cache_dir=cache_dir,
+        )
+
+    if cache_dir.is_file():
+        raise ValueError(
+            f'Scan cache expects a directory but found a file: {cache_dir}. Please use `cache_dir` argument or set `MODELSCOPE_CACHE` environment variable.'  # noqa: E501
+        )
+
+    repos: Set[CachedRepoInfo] = set()
+    warnings: List[CorruptedCacheException] = []
+
+    # ModelScope structure is different - we need to look in models/ and datasets/ directories
+    model_dir = cache_dir / 'models'
+    dataset_dir = cache_dir / 'datasets'
+
+    # Check models directory
+    if model_dir.exists() and model_dir.is_dir():
+        for repo_path in model_dir.iterdir():
+            if repo_path.name in FILES_TO_IGNORE or not repo_path.is_dir():
+                continue
+            try:
+                repos.add(
+                    _scan_cached_repo(repo_path, repo_type=REPO_TYPE_MODEL))
+            except CorruptedCacheException as e:
+                warnings.append(e)
+
+    # Check datasets directory
+    if dataset_dir.exists() and dataset_dir.is_dir():
+        for repo_path in dataset_dir.iterdir():
+            if repo_path.name in FILES_TO_IGNORE or not repo_path.is_dir():
+                continue
+            try:
+                repos.add(
+                    _scan_cached_repo(repo_path, repo_type=REPO_TYPE_DATASET))
+            except CorruptedCacheException as e:
+                warnings.append(e)
+
+    # Also check for repos directly in cache_dir (older structure)
+    for repo_path in cache_dir.iterdir():
+        if repo_path.name in ['models', 'datasets', '.locks'
+                              ] or repo_path.name in FILES_TO_IGNORE:
+            continue
+
+        if not repo_path.is_dir():
+            continue
+
+        try:
+            # Assume they are all models
+            repos.add(_scan_cached_repo(repo_path, repo_type=REPO_TYPE_MODEL))
+        except CorruptedCacheException as e:
+            warnings.append(e)
+
+    return ModelScopeCacheInfo(
+        repos=frozenset(repos),
+        size_on_disk=sum(repo.size_on_disk for repo in repos),
+        warnings=warnings,
+    )
+
+
+def _scan_cached_repo(repo_path: Path, repo_type: str) -> CachedRepoInfo:
+    """Scan a single cache repo and return information about it.
+
+    Any unexpected behavior will raise a [`~CorruptedCacheException`].
+    """
+    if not repo_path.is_dir():
+        raise CorruptedCacheException(
+            f'Repo path is not a directory: {repo_path}')
+
+    # ModelScope paths are directly structured as owner/name
+    # Extract repo_id from the path based on the parent directories
+    if repo_type == REPO_TYPE_MODEL and 'models' in str(repo_path.parent):
+        # For models stored in models/owner/name structure
+        repo_id = repo_path.name
+        if repo_path.parent and repo_path.parent.name not in ['models']:
+            repo_id = f'{repo_path.parent.name}/{repo_id}'
+    elif repo_type == REPO_TYPE_DATASET and 'datasets' in str(
+            repo_path.parent):
+        # For datasets stored in datasets/owner/name structure
+        repo_id = repo_path.name
+        if repo_path.parent and repo_path.parent.name not in ['datasets']:
+            repo_id = f'{repo_path.parent.name}/{repo_id}'
+    else:
+        # Fallback: assume the directory name is the repo ID or contains owner/name format
+        if '/' in repo_path.name:
+            repo_id = repo_path.name
+        else:
+            # Try to determine if parent directory might be the owner
+            parent_name = repo_path.parent.name
+            if parent_name not in ['models', 'datasets', 'hub']:
+                repo_id = f'{parent_name}/{repo_path.name}'
+            else:
+                repo_id = repo_path.name
+
+    # Validate repo type
+    if repo_type not in {REPO_TYPE_DATASET, REPO_TYPE_MODEL}:
+        raise CorruptedCacheException(
+            f'Repo type must be `dataset` or `model`, found `{repo_type}` ({repo_path}).'
+        )
+
+    # Use ModelFileSystemCache to get cached files information
+    try:
+        cache = ModelFileSystemCache(str(repo_path))
+        cached_files = cache.cached_files
+        cached_model_revision = cache.cached_model_revision
+    except Exception as e:
+        raise CorruptedCacheException(f'Failed to load cache information: {e}')
+
+    # In ModelScope, snapshots are stored directly in the repo directory
+    snapshots_path = repo_path / 'snapshots'
+    refs_path = repo_path / 'refs'
+
+    if not snapshots_path.exists() or not snapshots_path.is_dir():
+        raise CorruptedCacheException(
+            f"Snapshots dir doesn't exist in cached repo: {snapshots_path}")
+
+    # Scan over `refs` directory to get all references
+    refs_by_hash: Dict[str, Set[str]] = defaultdict(set)
+    if refs_path.exists():
+        if refs_path.is_file():
+            raise CorruptedCacheException(
+                f'Refs directory cannot be a file: {refs_path}')
+
+        for ref_path in refs_path.glob('**/*'):
+            # glob("**/*") iterates over all files and directories -> skip directories
+            if ref_path.is_dir() or ref_path.name in FILES_TO_IGNORE:
+                continue
+
+            ref_name = str(ref_path.relative_to(refs_path))
+            try:
+                with ref_path.open() as f:
+                    commit_hash = f.read().strip()
+                    refs_by_hash[commit_hash].add(ref_name)
+            except Exception as e:
+                raise CorruptedCacheException(
+                    f'Failed to read ref file {ref_path}: {e}')
+
+    # Scan snapshots directory to get revision information
+    cached_revisions: Set[CachedRevisionInfo] = set()
+    blob_stats = {}  # Track blob file stats
+
+    # Process each revision (snapshot)
+    for revision_path in snapshots_path.iterdir():
+        # Ignore OS-created helper files
+        if revision_path.name in FILES_TO_IGNORE:
+            continue
+        if revision_path.is_file():
+            raise CorruptedCacheException(
+                f'Snapshots folder corrupted. Found a file: {revision_path}')
+
+        # Collect information about files in this revision
+        cached_files_in_revision = set()
+        for file_path in revision_path.glob('**/*'):
+            # Skip directories and ignored files
+            if file_path.is_dir() or file_path.name in FILES_TO_IGNORE:
+                continue
+
+            # Get file stats
+            blob_path = file_path
+            if not blob_path.exists():
+                raise CorruptedCacheException(f'File missing: {blob_path}')
+
+            if blob_path not in blob_stats:
+                blob_stats[blob_path] = blob_path.stat()
+
+            # Create CachedFileInfo for this file
+            cached_files_in_revision.add(
+                CachedFileInfo(
+                    file_name=file_path.name,
+                    file_path=file_path,
+                    size_on_disk=blob_stats[blob_path].st_size,
+                    blob_path=blob_path,
+                    blob_last_accessed=blob_stats[blob_path].st_atime,
+                    blob_last_modified=blob_stats[blob_path].st_mtime,
+                ))
+
+        # Calculate revision metadata
+        if len(cached_files_in_revision) > 0:
+            revision_last_modified = max(blob_stats[file.blob_path].st_mtime
+                                         for file in cached_files_in_revision)
+        else:
+            revision_last_modified = revision_path.stat().st_mtime
+
+        # Add revision information
+        cached_revisions.add(
+            CachedRevisionInfo(
+                commit_hash=revision_path.name,
+                files=frozenset(cached_files_in_revision),
+                refs=frozenset(refs_by_hash.pop(revision_path.name, set())),
+                size_on_disk=sum(blob_stats[blob_path].st_size
+                                 for blob_path in set(
+                                     file.blob_path
+                                     for file in cached_files_in_revision)),
+                snapshot_path=revision_path,
+                last_modified=revision_last_modified,
+            ))
+
+    # Check that all refs referred to an existing revision
+    if len(refs_by_hash) > 0:
+        raise CorruptedCacheException(
+            f'Reference(s) refer to missing commit hashes: {dict(refs_by_hash)} ({repo_path}).'
+        )
+
+    # Calculate repository-wide statistics
+    if len(blob_stats) > 0:
+        repo_last_accessed = max(stat.st_atime for stat in blob_stats.values())
+        repo_last_modified = max(stat.st_mtime for stat in blob_stats.values())
+    else:
+        repo_stats = repo_path.stat()
+        repo_last_accessed = repo_stats.st_atime
+        repo_last_modified = repo_stats.st_mtime
+
+    # Build and return frozen structure
+    return CachedRepoInfo(
+        nb_files=len(blob_stats),
+        repo_id=repo_id,
+        repo_path=repo_path,
+        repo_type=repo_type,
+        revisions=frozenset(cached_revisions),
+        size_on_disk=sum(stat.st_size for stat in blob_stats.values()),
+        last_accessed=repo_last_accessed,
+        last_modified=repo_last_modified,
+    )

--- a/modelscope/hub/cache_manager.py
+++ b/modelscope/hub/cache_manager.py
@@ -1,17 +1,17 @@
 """Contains utilities to manage the ModelScope cache directory."""
 
 import os
-from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, FrozenSet, List, Literal, Optional, Set, Union
 
 from modelscope.hub.errors import CacheNotFound, CorruptedCacheException
 from modelscope.hub.utils.caching import ModelFileSystemCache
+from modelscope.hub.utils.utils import (convert_readable_size,
+                                        format_timesince, tabulate)
 from modelscope.utils.constant import REPO_TYPE_DATASET, REPO_TYPE_MODEL
 from modelscope.utils.file_utils import get_default_modelscope_cache_dir
 from modelscope.utils.logger import get_logger
-from .utils.utils import convert_readable_size, format_timesince, tabulate
 
 logger = get_logger()
 
@@ -232,7 +232,7 @@ class ModelScopeCacheInfo:
 
         Example:
         ```py
-        >>> from modelscope.hub.utils import scan_cache_dir
+        >>> from modelscope.hub.cache_manager import scan_cache_dir
 
         >>> ms_cache_info = scan_cache_dir()
         ModelScopeCacheInfo(...)

--- a/modelscope/hub/cache_manager.py
+++ b/modelscope/hub/cache_manager.py
@@ -1,5 +1,6 @@
 """Contains utilities to manage the ModelScope cache directory."""
 
+import os
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -90,10 +91,6 @@ class CachedRevisionInfo:
             exact tree structure as the repo on the Hub.
         files: (`FrozenSet[CachedFileInfo]`):
             Set of [`~CachedFileInfo`] describing all files contained in the snapshot.
-        refs (`FrozenSet[str]`):
-            Set of `refs` pointing to this revision. If the revision has no `refs`, it
-            is considered detached.
-            Example: `{"main", "2.4.0"}` or `{"refs/pr/1"}`.
         size_on_disk (`int`):
             Sum of the blob file sizes that are symlink-ed by the revision.
         last_modified (`float`):
@@ -104,7 +101,6 @@ class CachedRevisionInfo:
     snapshot_path: Path
     size_on_disk: int
     files: FrozenSet[CachedFileInfo]
-    refs: FrozenSet[str]
 
     last_modified: float
 
@@ -197,16 +193,6 @@ class CachedRepoInfo:
         """
         return convert_readable_size(self.size_on_disk)
 
-    @property
-    def refs(self) -> Dict[str, CachedRevisionInfo]:
-        """
-        (property) Mapping between `refs` and revision data structures.
-        """
-        return {
-            ref: revision
-            for revision in self.revisions for ref in revision.refs
-        }
-
 
 @dataclass(frozen=True)
 class ModelScopeCacheInfo:
@@ -242,7 +228,7 @@ class ModelScopeCacheInfo:
         """Generate a detailed table from the [`ModelScopeCacheInfo`] object.
 
         Returns a table with a row per repo and revision (thus multiple rows can appear for a single repo), with columns
-        "repo_id", "repo_type", "revision", "size_on_disk", "nb_files", "last_modified", "refs", "local_path".
+        "repo_id", "repo_type", "revision", "size_on_disk", "nb_files", "last_modified", "local_path".
 
         Example:
         ```py
@@ -252,11 +238,11 @@ class ModelScopeCacheInfo:
         ModelScopeCacheInfo(...)
 
         >>> print(ms_cache_info.export_as_table())
-        REPO ID                                             REPO TYPE REVISION                                      SIZE ON DISK NB FILES LAST_MODIFIED REFS LOCAL PATH
-        --------------------------------------------------- --------- -------------------------------------------- ------------ -------- ------------- ---- -------------------------------------------------------------
-        damo/bert-base-chinese                              model     9338f7b671827df886678df2bdd7cc7b4f36dffd             2.7M        5 1 week ago    main ~/.cache/modelscope/hub/models--damo--bert-base-chinese/...
-        damo/structured-bert                                model     76f64c2173c6ff1941f5ca08a23fa36611276874             8.8K        1 1 week ago    main ~/.cache/modelscope/hub/models--damo--structured-bert/...
-        damo/t5-base                                        model     d78aea13fa7ecd06c29e3e46195d6341255065d5           893.8M        4 7 months ago  main ~/.cache/modelscope/hub/models--damo--t5-base/...
+        REPO ID                                             REPO TYPE REVISION   SIZE ON DISK NB FILES LAST_MODIFIED LOCAL PATH
+        --------------------------------------------------- --------- ---------- ------------ -------- -------------  -------------------------------------------------------------
+        damo/bert-base-chinese                              model     master             2.7M        5 1 week ago     ~/.cache/modelscope/hub/models--damo--bert-base-chinese/...
+        damo/structured-bert                                model     master             8.8K        1 1 week ago     ~/.cache/modelscope/hub/models--damo--structured-bert/...
+        damo/t5-base                                        model     master           893.8M        4 7 months ago   ~/.cache/modelscope/hub/models--damo--t5-base/...
         ```
 
         Returns:
@@ -270,11 +256,11 @@ class ModelScopeCacheInfo:
                 repo.repo_id,
                 repo.repo_type,
                 revision.commit_hash,
-                '{:>12}'.format(revision.size_on_disk_str),
-                revision.nb_files,
-                revision.last_modified_str,
-                ', '.join(sorted(revision.refs)),
-                str(revision.snapshot_path),
+                '{:>12}'.format(repo.size_on_disk_str),
+                repo.nb_files,
+                repo.last_accessed_str,
+                repo.last_modified_str,
+                str(repo.repo_path),
             ]
 
         column_headers = [
@@ -283,14 +269,14 @@ class ModelScopeCacheInfo:
             'REVISION',
             'SIZE ON DISK',
             'NB FILES',
+            'LAST_ACCESSED',
             'LAST_MODIFIED',
-            'REFS',
             'LOCAL PATH',
         ]
 
         table_data = [
             format_repo_revision(repo, revision)
-            for repo in sorted(self.repos, key=lambda repo: repo.repo_path)
+            for repo in sorted(self.repos, key=lambda repo: repo.repo_id)
             for revision in sorted(
                 repo.revisions, key=lambda revision: revision.commit_hash)
         ]
@@ -325,7 +311,7 @@ def scan_cache_dir(
                 nb_files=11,
                 revisions=frozenset({
                     CachedRevisionInfo(
-                        commit_hash='d78aea13fa7ecd06c29e3e46195d6341255065d5',
+                        commit_hash='master',
                         size_on_disk=970726339,
                         snapshot_path=PosixPath(...),
                         files=frozenset({
@@ -388,40 +374,26 @@ def scan_cache_dir(
 
     # Check models directory
     if model_dir.exists() and model_dir.is_dir():
-        for repo_path in model_dir.iterdir():
-            if repo_path.name in FILES_TO_IGNORE or not repo_path.is_dir():
-                continue
-            try:
-                repos.add(
-                    _scan_cached_repo(repo_path, repo_type=REPO_TYPE_MODEL))
-            except CorruptedCacheException as e:
-                warnings.append(e)
+        # First level directories are owners/organizations
+        model_repos, model_warnings = _scan_dir(
+            model_dir, repo_type=REPO_TYPE_MODEL)
+        repos.update(model_repos)
+        warnings.extend(model_warnings)
 
     # Check datasets directory
     if dataset_dir.exists() and dataset_dir.is_dir():
-        for repo_path in dataset_dir.iterdir():
-            if repo_path.name in FILES_TO_IGNORE or not repo_path.is_dir():
-                continue
-            try:
-                repos.add(
-                    _scan_cached_repo(repo_path, repo_type=REPO_TYPE_DATASET))
-            except CorruptedCacheException as e:
-                warnings.append(e)
+        # First level directories are owners/organizations
+        dataset_repos, dataset_warnings = _scan_dir(
+            dataset_dir, repo_type=REPO_TYPE_DATASET)
+        repos.update(dataset_repos)
+        warnings.extend(dataset_warnings)
 
     # Also check for repos directly in cache_dir (older structure)
-    for repo_path in cache_dir.iterdir():
-        if repo_path.name in ['models', 'datasets', '.locks'
-                              ] or repo_path.name in FILES_TO_IGNORE:
-            continue
-
-        if not repo_path.is_dir():
-            continue
-
-        try:
-            # Assume they are all models
-            repos.add(_scan_cached_repo(repo_path, repo_type=REPO_TYPE_MODEL))
-        except CorruptedCacheException as e:
-            warnings.append(e)
+    # If the repo is not in models/ or datasets/, assume it's a model repo
+    other_repos, other_warnings = _scan_dir(
+        cache_dir, repo_type=REPO_TYPE_MODEL, extended=True)
+    repos.update(other_repos)
+    warnings.extend(other_warnings)
 
     return ModelScopeCacheInfo(
         repos=frozenset(repos),
@@ -430,7 +402,44 @@ def scan_cache_dir(
     )
 
 
-def _scan_cached_repo(repo_path: Path, repo_type: str) -> CachedRepoInfo:
+def _is_valid_dir(dir: Path) -> bool:
+    """Check if a directory is valid for scanning."""
+    if not dir.exists():
+        return False
+    if not dir.is_dir():
+        return False
+    if dir.is_symlink():
+        return False
+    if dir.name in FILES_TO_IGNORE:
+        return False
+    return True
+
+
+def _scan_dir(dir: Path, repo_type: str, extended: bool = False):
+    """Scan a directory for cached repos and return a set of [`~CachedRepoInfo`] and warnings."""
+    repos = set()
+    warnings = []
+    for owner_dir in dir.iterdir():
+        # not extend scan the following dirs
+        if extended and owner_dir.name in ['models', 'datasets', 'hub']:
+            continue
+        if not _is_valid_dir(owner_dir):
+            continue
+        # Second level directories are repo names
+        for name_dir in owner_dir.iterdir():
+            if not _is_valid_dir(name_dir):
+                continue
+            try:
+                info = _scan_cached_repo(name_dir, repo_type=repo_type)
+                if info is not None:
+                    repos.add(info)
+            except CorruptedCacheException as e:
+                warnings.append(e)
+    return repos, warnings
+
+
+def _scan_cached_repo(repo_path: Path,
+                      repo_type: str) -> Optional[CachedRepoInfo]:
     """Scan a single cache repo and return information about it.
 
     Any unexpected behavior will raise a [`~CorruptedCacheException`].
@@ -439,142 +448,69 @@ def _scan_cached_repo(repo_path: Path, repo_type: str) -> CachedRepoInfo:
         raise CorruptedCacheException(
             f'Repo path is not a directory: {repo_path}')
 
-    # ModelScope paths are directly structured as owner/name
-    # Extract repo_id from the path based on the parent directories
-    if repo_type == REPO_TYPE_MODEL and 'models' in str(repo_path.parent):
-        # For models stored in models/owner/name structure
-        repo_id = repo_path.name
-        if repo_path.parent and repo_path.parent.name not in ['models']:
-            repo_id = f'{repo_path.parent.name}/{repo_id}'
-    elif repo_type == REPO_TYPE_DATASET and 'datasets' in str(
-            repo_path.parent):
-        # For datasets stored in datasets/owner/name structure
-        repo_id = repo_path.name
-        if repo_path.parent and repo_path.parent.name not in ['datasets']:
-            repo_id = f'{repo_path.parent.name}/{repo_id}'
-    else:
-        # Fallback: assume the directory name is the repo ID or contains owner/name format
-        if '/' in repo_path.name:
-            repo_id = repo_path.name
-        else:
-            # Try to determine if parent directory might be the owner
-            parent_name = repo_path.parent.name
-            if parent_name not in ['models', 'datasets', 'hub']:
-                repo_id = f'{parent_name}/{repo_path.name}'
-            else:
-                repo_id = repo_path.name
-
-    # Validate repo type
-    if repo_type not in {REPO_TYPE_DATASET, REPO_TYPE_MODEL}:
-        raise CorruptedCacheException(
-            f'Repo type must be `dataset` or `model`, found `{repo_type}` ({repo_path}).'
-        )
-
     # Use ModelFileSystemCache to get cached files information
     try:
         cache = ModelFileSystemCache(str(repo_path))
         cached_files = cache.cached_files
         cached_model_revision = cache.cached_model_revision
+        repo_id = cache.get_model_id().replace('___', '.')
+
+        if repo_id == 'unknown':
+            return None  # Skip if repo_id is unknown
     except Exception as e:
         raise CorruptedCacheException(f'Failed to load cache information: {e}')
 
-    # In ModelScope, snapshots are stored directly in the repo directory
-    snapshots_path = repo_path / 'snapshots'
-    refs_path = repo_path / 'refs'
-
-    if not snapshots_path.exists() or not snapshots_path.is_dir():
-        raise CorruptedCacheException(
-            f"Snapshots dir doesn't exist in cached repo: {snapshots_path}")
-
-    # Scan over `refs` directory to get all references
-    refs_by_hash: Dict[str, Set[str]] = defaultdict(set)
-    if refs_path.exists():
-        if refs_path.is_file():
-            raise CorruptedCacheException(
-                f'Refs directory cannot be a file: {refs_path}')
-
-        for ref_path in refs_path.glob('**/*'):
-            # glob("**/*") iterates over all files and directories -> skip directories
-            if ref_path.is_dir() or ref_path.name in FILES_TO_IGNORE:
-                continue
-
-            ref_name = str(ref_path.relative_to(refs_path))
-            try:
-                with ref_path.open() as f:
-                    commit_hash = f.read().strip()
-                    refs_by_hash[commit_hash].add(ref_name)
-            except Exception as e:
-                raise CorruptedCacheException(
-                    f'Failed to read ref file {ref_path}: {e}')
-
-    # Scan snapshots directory to get revision information
-    cached_revisions: Set[CachedRevisionInfo] = set()
+    # Collect file stats and information
     blob_stats = {}  # Track blob file stats
+    cached_files_info = set()
 
-    # Process each revision (snapshot)
-    for revision_path in snapshots_path.iterdir():
-        # Ignore OS-created helper files
-        if revision_path.name in FILES_TO_IGNORE:
+    # Process all cached files
+    for cached_file in cached_files:
+        file_path = os.path.join(repo_path, cached_file['Path'])
+        if not os.path.exists(file_path):
             continue
-        if revision_path.is_file():
-            raise CorruptedCacheException(
-                f'Snapshots folder corrupted. Found a file: {revision_path}')
 
-        # Collect information about files in this revision
-        cached_files_in_revision = set()
-        for file_path in revision_path.glob('**/*'):
-            # Skip directories and ignored files
-            if file_path.is_dir() or file_path.name in FILES_TO_IGNORE:
-                continue
+        blob_path = Path(file_path)
+        blob_stats[blob_path] = blob_path.stat()
 
-            # Get file stats
-            blob_path = file_path
-            if not blob_path.exists():
-                raise CorruptedCacheException(f'File missing: {blob_path}')
-
-            if blob_path not in blob_stats:
-                blob_stats[blob_path] = blob_path.stat()
-
-            # Create CachedFileInfo for this file
-            cached_files_in_revision.add(
-                CachedFileInfo(
-                    file_name=file_path.name,
-                    file_path=file_path,
-                    size_on_disk=blob_stats[blob_path].st_size,
-                    blob_path=blob_path,
-                    blob_last_accessed=blob_stats[blob_path].st_atime,
-                    blob_last_modified=blob_stats[blob_path].st_mtime,
-                ))
-
-        # Calculate revision metadata
-        if len(cached_files_in_revision) > 0:
-            revision_last_modified = max(blob_stats[file.blob_path].st_mtime
-                                         for file in cached_files_in_revision)
-        else:
-            revision_last_modified = revision_path.stat().st_mtime
-
-        # Add revision information
-        cached_revisions.add(
-            CachedRevisionInfo(
-                commit_hash=revision_path.name,
-                files=frozenset(cached_files_in_revision),
-                refs=frozenset(refs_by_hash.pop(revision_path.name, set())),
-                size_on_disk=sum(blob_stats[blob_path].st_size
-                                 for blob_path in set(
-                                     file.blob_path
-                                     for file in cached_files_in_revision)),
-                snapshot_path=revision_path,
-                last_modified=revision_last_modified,
+        # Create CachedFileInfo for this file
+        cached_files_info.add(
+            CachedFileInfo(
+                file_name=os.path.basename(cached_file['Path']),
+                file_path=blob_path,
+                size_on_disk=blob_stats[blob_path].st_size,
+                blob_path=blob_path,
+                blob_last_accessed=blob_stats[blob_path].st_atime,
+                blob_last_modified=blob_stats[blob_path].st_mtime,
             ))
 
-    # Check that all refs referred to an existing revision
-    if len(refs_by_hash) > 0:
-        raise CorruptedCacheException(
-            f'Reference(s) refer to missing commit hashes: {dict(refs_by_hash)} ({repo_path}).'
-        )
+    # Create a single revision from cached files
+    revision_hash = 'master'  # Default revision name
+    if cached_model_revision:
+        # Extract revision hash from cached_model_revision if available
+        if 'Revision:' in cached_model_revision:
+            revision_hash = cached_model_revision.split('Revision:')[1].split(
+                ',')[0]
+
+    # Calculate revision metadata
+    if cached_files_info:
+        revision_last_modified = max(blob_stats[file.blob_path].st_mtime
+                                     for file in cached_files_info)
+    else:
+        revision_last_modified = repo_path.stat().st_mtime
+
+    # Create a CachedRevisionInfo for the repository
+    cached_revision = CachedRevisionInfo(
+        commit_hash=revision_hash,
+        files=frozenset(cached_files_info),
+        size_on_disk=sum(blob_stats[file.blob_path].st_size
+                         for file in cached_files_info),
+        snapshot_path=repo_path,
+        last_modified=revision_last_modified,
+    )
 
     # Calculate repository-wide statistics
-    if len(blob_stats) > 0:
+    if blob_stats:
         repo_last_accessed = max(stat.st_atime for stat in blob_stats.values())
         repo_last_modified = max(stat.st_mtime for stat in blob_stats.values())
     else:
@@ -588,7 +524,7 @@ def _scan_cached_repo(repo_path: Path, repo_type: str) -> CachedRepoInfo:
         repo_id=repo_id,
         repo_path=repo_path,
         repo_type=repo_type,
-        revisions=frozenset(cached_revisions),
+        revisions=frozenset([cached_revision]),
         size_on_disk=sum(stat.st_size for stat in blob_stats.values()),
         last_accessed=repo_last_accessed,
         last_modified=repo_last_modified,

--- a/modelscope/hub/errors.py
+++ b/modelscope/hub/errors.py
@@ -2,7 +2,8 @@
 
 import logging
 from http import HTTPStatus
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 import requests
 from requests.exceptions import HTTPError
@@ -47,6 +48,20 @@ class FileIntegrityError(Exception):
 
 class FileDownloadError(Exception):
     pass
+
+
+class CacheNotFound(Exception):
+    """Exception thrown when the ModelScope cache is not found."""
+
+    cache_dir: Union[str, Path]
+
+    def __init__(self, msg: str, cache_dir: Union[str, Path], *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+        self.cache_dir = cache_dir
+
+
+class CorruptedCacheException(Exception):
+    """Exception for any unexpected structure in the ModelScope cache-system."""
 
 
 def get_request_id(response: requests.Response):

--- a/modelscope/hub/file_download.py
+++ b/modelscope/hub/file_download.py
@@ -307,7 +307,7 @@ def move_legacy_cache_to_standard_dir(cache_dir: str, model_id: str):
         #   When MODELSCOPE_CACHE is not set, the default directory remains
         #   the same at  ~/.cache/modelscope/hub
         # Scenery 2:
-        #   When MODELSCOPE_CACHE is not set, the cache directory is moved from
+        #   When MODELSCOPE_CACHE is set, the cache directory is moved from
         #   $MODELSCOPE_CACHE/hub to $MODELSCOPE_CACHE/. In this case,
         #   we will be migrating the hub directory accordingly.
         legacy_cache_root = os.path.join(legacy_cache_root, 'hub')

--- a/modelscope/hub/utils/caching.py
+++ b/modelscope/hub/utils/caching.py
@@ -126,7 +126,7 @@ class ModelFileSystemCache(FileSystemCache):
     def __init__(self, cache_root, owner=None, name=None):
         """Put file to the cache
         Args:
-            cache_root(`str`): The modelscope local cache root(default: ~/.cache/modelscope/)
+            cache_root(`str`): The modelscope local cache root(default: ~/.cache/modelscope/hub)
             owner(`str`): The model owner.
             name('str'): The name of the model
         Returns:

--- a/modelscope/hub/utils/utils.py
+++ b/modelscope/hub/utils/utils.py
@@ -3,7 +3,8 @@
 import hashlib
 import os
 import sys
-from datetime import datetime, time
+import time
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -215,8 +216,6 @@ _TIMESINCE_CHUNKS = (
 
 def format_timesince(ts: float) -> str:
     """Format timestamp in seconds into a human-readable string, relative to now.
-
-    Vaguely inspired by Django's `timesince` formatter.
     """
     delta = time.time() - ts
     if delta < 20:

--- a/tests/cli/test_scancache_cmd.py
+++ b/tests/cli/test_scancache_cmd.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import sys
+import unittest
+
+from modelscope.utils.file_utils import get_modelscope_cache_dir
+
+
+class TestScanCacheCommand(unittest.TestCase):
+    """Test cases for scancache command in ModelScope CLI."""
+
+    def setUp(self):
+        """Set up for tests."""
+        self.fake_cache_dir = '/fake/cache/path'
+
+    def test_scan_default_dir(self):
+        cmd = 'python -m modelscope.cli.cli scan-cache'
+        stat, output = subprocess.getstatusoutput(cmd)
+        self.assertEqual(stat, 0)
+        self.assertIn('Done', output)
+
+    def test_scan_given_dir(self):
+        cmd = f'python -m modelscope.cli.cli scan-cache --dir {get_modelscope_cache_dir()}'
+        stat, output = subprocess.getstatusoutput(cmd)
+        self.assertEqual(stat, 0)
+        self.assertIn('Done', output)
+
+    def test_scan_not_exist_dir(self):
+        cmd = f'python -m modelscope.cli.cli scan-cache --dir {self.fake_cache_dir}'
+        stat, output = subprocess.getstatusoutput(cmd)
+        self.assertEqual(stat, 0)
+        self.assertIn('not found', output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cli/test_scancache_cmd.py
+++ b/tests/cli/test_scancache_cmd.py
@@ -9,9 +9,13 @@ from modelscope.utils.file_utils import get_modelscope_cache_dir
 class TestScanCacheCommand(unittest.TestCase):
     """Test cases for scancache command in ModelScope CLI."""
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Set up for tests."""
-        self.fake_cache_dir = '/fake/cache/path'
+        # download one file to ensure the cache directory exists
+        model_id = 'Qwen/Qwen3-0.6B'
+        cmd = f'python -m modelscope.cli.cli download --model {model_id} README.md'
+        subprocess.getstatusoutput(cmd)
 
     def test_scan_default_dir(self):
         cmd = 'python -m modelscope.cli.cli scan-cache'
@@ -26,7 +30,7 @@ class TestScanCacheCommand(unittest.TestCase):
         self.assertIn('Done', output)
 
     def test_scan_not_exist_dir(self):
-        cmd = f'python -m modelscope.cli.cli scan-cache --dir {self.fake_cache_dir}'
+        cmd = 'python -m modelscope.cli.cli scan-cache --dir /fake/cache/path'
         stat, output = subprocess.getstatusoutput(cmd)
         self.assertEqual(stat, 0)
         self.assertIn('not found', output)

--- a/tests/hub/test_hub_scan_cache.py
+++ b/tests/hub/test_hub_scan_cache.py
@@ -1,6 +1,7 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 import unittest
 
+from modelscope import snapshot_download
 from modelscope.hub.cache_manager import scan_cache_dir
 from modelscope.hub.errors import CacheNotFound
 from modelscope.utils.file_utils import get_modelscope_cache_dir
@@ -11,9 +12,12 @@ logger = get_logger()
 
 class HubScanCacheTest(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Set up for tests."""
-        self.fake_cache_dir = '/fake/cache/path'
+        # download one file to ensure the cache directory exists
+        model_id = 'Qwen/Qwen3-0.6B'
+        snapshot_download(model_id, allow_file_pattern='README.md')
 
     def test_scan_default_dir(self):
         """Test scanning the default cache directory."""

--- a/tests/hub/test_hub_scan_cache.py
+++ b/tests/hub/test_hub_scan_cache.py
@@ -1,0 +1,41 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+import unittest
+
+from modelscope.hub.cache_manager import scan_cache_dir
+from modelscope.hub.errors import CacheNotFound
+from modelscope.utils.file_utils import get_modelscope_cache_dir
+from modelscope.utils.logger import get_logger
+
+logger = get_logger()
+
+
+class HubScanCacheTest(unittest.TestCase):
+
+    def setUp(self):
+        """Set up for tests."""
+        self.fake_cache_dir = '/fake/cache/path'
+
+    def test_scan_default_dir(self):
+        """Test scanning the default cache directory."""
+        try:
+            res_info = scan_cache_dir()
+            logger.info(res_info.export_as_table())
+        except Exception as e:
+            self.fail(f'Scanning default cache directory failed: {e}')
+
+    def test_scan_given_dir(self):
+        """Test scanning a given cache directory."""
+        try:
+            scan_cache_dir(get_modelscope_cache_dir())
+            logger.info('Done')
+        except Exception as e:
+            self.fail(f'Scanning given cache directory failed: {e}')
+
+    def test_scan_not_exist_dir(self):
+        """Test scanning a non-existent cache directory."""
+        with self.assertRaises(CacheNotFound):
+            scan_cache_dir('/non/existent/path')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Scan snapshot downloaded datasets and models in ModelScope cache dir. #1326 

Usage:
```py
>>> from modelscope.hub.cache_manager import scan_cache_dir

>>> ms_cache_info = scan_cache_dir()
ModelScopeCacheInfo(...)

>>> print(ms_cache_info.export_as_table())

REPO ID             REPO TYPE REVISION SIZE ON DISK NB FILES LAST_ACCESSED LAST_MODIFIED LOCAL PATH                                               
------------------- --------- -------- ------------ -------- ------------- ------------- -------------------------------------------------------- 
AI-ModelScope/IQuiz dataset   master        5.23 MB        8 4 hours ago   4 hours ago   /root/.cache/modelscope/hub/datasets/AI-ModelScope/IQuiz 
Qwen/Qwen3-0.6B     model     master        1.41 GB        9 4 hours ago   4 hours ago   /root/.cache/modelscope/hub/models/Qwen/Qwen3-0___6B 
```

CLI:

Scan default cache dir:
```bash
>>> modelscope scan-cache

REPO ID             REPO TYPE REVISION SIZE ON DISK NB FILES LAST_ACCESSED LAST_MODIFIED LOCAL PATH                                               
------------------- --------- -------- ------------ -------- ------------- ------------- -------------------------------------------------------- 
AI-ModelScope/IQuiz dataset   master        5.23 MB        8 4 hours ago   4 hours ago   /root/.cache/modelscope/hub/datasets/AI-ModelScope/IQuiz 
Qwen/Qwen3-0.6B     model     master        1.41 GB        9 4 hours ago   4 hours ago   /root/.cache/modelscope/hub/models/Qwen/Qwen3-0___6B     

Done in 0.0s. Scanned 2 repo(s) for a total of 1.42 GB.
```
or specify `--dir`:
```bash
>>> modelscope scan-cache --dir /mnt/workspace/.cache/modelscope
...
Done in 43.1s. Scanned 349 repo(s) for a total of 4.45 TB.
```