### PR TITLE
解决使用`uv tool`的依赖的问题

### DIFF
--- a/requirements/hub.txt
+++ b/requirements/hub.txt
@@ -2,3 +2,4 @@ requests>=2.25
 setuptools
 tqdm>=4.64.0
 urllib3>=1.26
+filelock


### PR DESCRIPTION
**希望解决的UseCase：**
使用`uv tool install modelscope`安装modelscope，然后使用`modelscope download`下载模型时会报缺少`filelock`的依赖，原因是requirements中缺少显示的写明filelock.

**没解决的次要UseCase：**
在modelscope项目内使用`uv tool install .`安装会出现import circle，原因是setup.py中 `from modelscope.utils.constant import Fields` 导致；
我担心这个有其他的作用，希望作者可以关注。