### PR TITLE
Fix intermixed missing in cli_argument_parser.py

### DIFF
--- a/modelscope/trainers/cli_argument_parser.py
+++ b/modelscope/trainers/cli_argument_parser.py
@@ -21,12 +21,17 @@ class CliArgumentParser(ArgumentParser):
     def get_manual_args(self, args):
         return [arg[2:] for arg in args if arg.startswith('--')]
 
-    def _parse_known_args(self, args: List = None, namespace=None, *args_extra, **kwargs):
+    def _parse_known_args(self,
+                          args: List = None,
+                          namespace=None,
+                          *args_extra,
+                          **kwargs):
         self.model_id = namespace.model if namespace is not None else None
         if '--model' in args:
             self.model_id = args[args.index('--model') + 1]
         self.manual_args = self.get_manual_args(args)
-        return super()._parse_known_args(args, namespace, *args_extra, **kwargs)
+        return super()._parse_known_args(args, namespace, *args_extra,
+                                         **kwargs)
 
     def print_help(self, file=None):
         return super().print_help(file)

--- a/modelscope/trainers/cli_argument_parser.py
+++ b/modelscope/trainers/cli_argument_parser.py
@@ -21,12 +21,12 @@ class CliArgumentParser(ArgumentParser):
     def get_manual_args(self, args):
         return [arg[2:] for arg in args if arg.startswith('--')]
 
-    def _parse_known_args(self, args: List = None, namespace=None, intermixed=None):
+    def _parse_known_args(self, args: List = None, namespace=None, *args_extra, **kwargs):
         self.model_id = namespace.model if namespace is not None else None
         if '--model' in args:
             self.model_id = args[args.index('--model') + 1]
         self.manual_args = self.get_manual_args(args)
-        return super()._parse_known_args(args, namespace, intermixed)
+        return super()._parse_known_args(args, namespace, *args_extra, **kwargs)
 
     def print_help(self, file=None):
         return super().print_help(file)

--- a/modelscope/trainers/cli_argument_parser.py
+++ b/modelscope/trainers/cli_argument_parser.py
@@ -21,12 +21,12 @@ class CliArgumentParser(ArgumentParser):
     def get_manual_args(self, args):
         return [arg[2:] for arg in args if arg.startswith('--')]
 
-    def _parse_known_args(self, args: List = None, namespace=None):
+    def _parse_known_args(self, args: List = None, namespace=None, intermixed=None):
         self.model_id = namespace.model if namespace is not None else None
         if '--model' in args:
             self.model_id = args[args.index('--model') + 1]
         self.manual_args = self.get_manual_args(args)
-        return super()._parse_known_args(args, namespace)
+        return super()._parse_known_args(args, namespace, intermixed)
 
     def print_help(self, file=None):
         return super().print_help(file)


### PR DESCRIPTION
When using `TrainingArgs`, the following error was encountered:
```
Traceback (most recent call last):
  File "/home/sunyaqiang/work/SD-Factory/stable_diffusion/finetune_stable_diffusion.py", line 61, in <module>
    training_args = StableDiffusionLoraArguments(task='text-to-image-synthesis').parse_cli()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sunyaqiang/anaconda3/envs/swift/lib/python3.12/site-packages/modelscope/trainers/training_args.py", line 449, in parse_cli
    args, unknown = parser.parse_known_args(parser_args)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sunyaqiang/anaconda3/envs/swift/lib/python3.12/argparse.py", line 1914, in parse_known_args
    return self._parse_known_args2(args, namespace, intermixed=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sunyaqiang/anaconda3/envs/swift/lib/python3.12/argparse.py", line 1943, in _parse_known_args2
    namespace, args = self._parse_known_args(args, namespace, intermixed)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CliArgumentParser._parse_known_args() takes from 1 to 3 positional arguments but 4 were given
```
The class `CliArgumentParser` inherits from `argparse.ArgumentParser`, and the `_parse_known_args` function in `ArgumentParser` need `intermixed`.
