### PR TITLE
Feat/support commit scheduler

### DIFF
--- a/modelscope/hub/__init__.py
+++ b/modelscope/hub/__init__.py
@@ -1,1 +1,2 @@
 from .callback import ProgressCallback
+from .commit_scheduler import CommitScheduler

--- a/modelscope/hub/commit_scheduler.py
+++ b/modelscope/hub/commit_scheduler.py
@@ -1,0 +1,309 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+import atexit
+import os
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from io import SEEK_END, SEEK_SET, BytesIO
+from pathlib import Path
+from threading import Lock, Thread
+from typing import Dict, List, Optional, Union
+
+from modelscope.hub.api import HubApi
+from modelscope.utils.logger import get_logger
+from modelscope.utils.repo_utils import (CommitInfo, CommitOperationAdd,
+                                         RepoUtils)
+
+logger = get_logger()
+
+IGNORE_GIT_FOLDER_PATTERNS = ['.git', '.git/*', '*/.git', '**/.git/**']
+
+
+@dataclass(frozen=True)
+class _FileToUpload:
+    """Information about a file to upload."""
+
+    local_path: Path
+    path_in_repo: str
+    size_limit: int
+    last_modified: float
+
+
+class CommitScheduler:
+    """Scheduler to regularly push a local folder to ModelScope Hub."""
+
+    def __init__(
+        self,
+        *,
+        repo_id: str,
+        folder_path: Union[str, Path],
+        interval: Union[int, float] = 5,
+        path_in_repo: Optional[str] = None,
+        repo_type: Optional[str] = None,
+        revision: Optional[str] = None,
+        private: Optional[bool] = None,
+        token: Optional[str] = None,
+        allow_patterns: Optional[Union[List[str], str]] = None,
+        ignore_patterns: Optional[Union[List[str], str]] = None,
+        squash_history: bool = False,
+        hub_api: Optional['HubApi'] = None,
+    ) -> None:
+        self.api = hub_api or HubApi()
+
+        # Folder
+        self.folder_path = Path(folder_path).expanduser().resolve()
+        if not self.folder_path.exists():
+            raise ValueError(f'Folder path does not exist: {folder_path}')
+
+        self.path_in_repo = path_in_repo or ''
+        self.allow_patterns = allow_patterns
+
+        if ignore_patterns is None:
+            ignore_patterns = []
+        elif isinstance(ignore_patterns, str):
+            ignore_patterns = [ignore_patterns]
+        self.ignore_patterns = ignore_patterns + IGNORE_GIT_FOLDER_PATTERNS
+
+        repo_url = self.api.create_repo(
+            repo_id=repo_id,
+            token=token,
+            repo_type=repo_type,
+            visibility='private' if private else 'public',
+            exist_ok=True,
+            create_default_config=False,
+        )
+        self.repo_id = repo_url.repo_id
+        self.repo_type = repo_type
+        self.revision = revision
+        self.token = token
+
+        # Keep track of already uploaded files
+        self.last_uploaded: Dict[Path, float] = {}
+
+        if interval <= 0:
+            raise ValueError(
+                f'"interval" must be a positive integer, not "{interval}".')
+        self.lock = Lock()
+        self.interval = interval
+        self.squash_history = squash_history
+
+        logger.info(
+            f'Scheduled job to push {self.folder_path} to {self.repo_id} at a interval of {self.interval} minutes.'
+        )
+        self.executor = ThreadPoolExecutor(max_workers=1)
+        self._scheduler_thread = Thread(
+            target=self._run_scheduler, daemon=True)
+        self._scheduler_thread.start()
+        atexit.register(self.push_to_hub)
+
+        self.__stopped = False
+
+    def stop(self) -> None:
+        """Stop the scheduler."""
+        self.__stopped = True
+
+    def _run_scheduler(self) -> None:
+        while True:
+            self.last_future = self.trigger()
+            time.sleep(self.interval * 60)
+            if self.__stopped:
+                break
+
+    def trigger(self) -> Future:
+        """Trigger a background commit and return a future."""
+        return self.executor.submit(self._push_to_hub)
+
+    def _push_to_hub(self) -> Optional[CommitInfo]:
+        if self.__stopped:
+            return None
+
+        logger.info('(Background) scheduled commit triggered.')
+        try:
+            value = self.push_to_hub()
+            if value and self.squash_history and hasattr(
+                    self.api, 'super_squash_history'):
+                logger.info('(Background) squashing repo history.')
+                try:
+                    self.api.super_squash_history(
+                        repo_id=self.repo_id,
+                        repo_type=self.repo_type,
+                        branch=self.revision)
+                except Exception as e:
+                    logger.error(f'Error while squashing history: {e}')
+                    # Don't raise here as the commit was successful
+            return value
+        except Exception as e:
+            logger.error(f'Error while pushing to Hub: {e}')
+            raise
+
+    def push_to_hub(self) -> Optional[CommitInfo]:
+        """Push folder to the Hub and return commit info if changes are found."""
+        try:
+            files = []
+            for path in self.folder_path.rglob('*'):
+                if not path.is_file():
+                    continue
+                relpath = path.relative_to(self.folder_path).as_posix()
+                if not RepoUtils.filter_repo_objects(
+                    [relpath],
+                        allow_patterns=self.allow_patterns,
+                        ignore_patterns=self.ignore_patterns):
+                    continue
+                files.append((relpath, path))
+        except Exception as e:
+            logger.error(f'Error while scanning files: {e}')
+            raise
+
+        with self.lock:
+            try:
+                prefix = f'{self.path_in_repo.strip("/")}/' if self.path_in_repo else ''
+                files_to_upload: List[_FileToUpload] = []
+
+                for relpath, local_path in files:
+                    try:
+                        stat = local_path.stat()
+                        if self.last_uploaded.get(
+                                local_path) is None or self.last_uploaded[
+                                    local_path] != stat.st_mtime:
+                            files_to_upload.append(
+                                _FileToUpload(
+                                    local_path=local_path,
+                                    path_in_repo=prefix + relpath,
+                                    size_limit=stat.st_size,
+                                    last_modified=stat.st_mtime))
+                    except OSError as e:
+                        logger.warning(
+                            f'Failed to stat file {local_path}: {e}')
+                        continue
+
+                if not files_to_upload:
+                    logger.debug(
+                        'Dropping schedule commit: no changed file to upload.')
+                    return None
+            finally:
+                pass
+
+        add_operations = []
+        for file in files_to_upload:
+            try:
+                add_operations.append(
+                    CommitOperationAdd(
+                        path_or_fileobj=PartialFileIO(
+                            file.local_path, size_limit=file.size_limit),
+                        path_in_repo=file.path_in_repo,
+                    ))
+            except Exception as e:
+                logger.warning(
+                    f'Failed to create operation for {file.local_path}: {e}')
+                continue
+
+        if not add_operations:
+            logger.debug('No valid operations to perform.')
+            return None
+
+        try:
+            logger.debug('Uploading files for scheduled commit.')
+            commit_info = self.api.create_commit(
+                repo_id=self.repo_id,
+                repo_type=self.repo_type,
+                operations=add_operations,
+                commit_message='Scheduled Commit',
+                revision=self.revision,
+                token=self.token,
+            )
+        except Exception as e:
+            logger.error(f'Error during commit: {e}')
+            raise
+
+        for file in files_to_upload:
+            self.last_uploaded[file.local_path] = file.last_modified
+
+        return commit_info
+
+
+class PartialFileIO(BytesIO):
+    """A file-like object that reads only the first part of a file."""
+
+    def __init__(self, file_path: Union[str, Path], size_limit: int) -> None:
+        self._file_path = Path(file_path)
+        self._file = None
+        self._size_limit = None
+        self.open()
+
+    def open(self) -> None:
+        """Open the file and initialize size limit."""
+        if self._file is not None:
+            return
+        try:
+            self._file = self._file_path.open('rb')
+            self._size_limit = min(
+                self._size_limit or float('inf'),
+                os.fstat(self._file.fileno()).st_size)
+        except OSError as e:
+            logger.error(f'Failed to open file {self._file_path}: {e}')
+            raise
+
+    def close(self) -> None:
+        """Close the file if it's open."""
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def __enter__(self) -> 'PartialFileIO':
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        return f'<PartialFileIO file_path={self._file_path} size_limit={self._size_limit}>'
+
+    def __len__(self) -> int:
+        if self._size_limit is None:
+            self.open()
+        return self._size_limit
+
+    def __getattribute__(self, name: str):
+        if name.startswith('_') or name in {
+                'read', 'tell', 'seek', 'close', 'open', '__enter__',
+                '__exit__'
+        }:
+            return super().__getattribute__(name)
+        raise NotImplementedError(
+            f'{self.__class__.__name__} does not support {name}')
+
+    def tell(self) -> int:
+        if self._file is None:
+            self.open()
+        return self._file.tell()
+
+    def seek(self, __offset: int, __whence: int = SEEK_SET) -> int:
+        """Seek to a position in the file, but never beyond size_limit."""
+        if self._file is None:
+            self.open()
+
+        if __whence == SEEK_END:
+            __offset = len(self) + __offset
+            __whence = SEEK_SET
+
+        target_pos = __offset if __whence == SEEK_SET else self.tell(
+        ) + __offset
+        target_pos = min(target_pos, self._size_limit)
+
+        return self._file.seek(target_pos, SEEK_SET)
+
+    def read(self, __size: Optional[int] = -1) -> bytes:
+        """Read at most size_limit bytes from the current position."""
+        if self._file is None:
+            self.open()
+
+        current = self.tell()
+        if __size is None or __size < 0:
+            truncated_size = self._size_limit - current
+        else:
+            truncated_size = min(__size, self._size_limit - current)
+        return self._file.read(truncated_size)

--- a/modelscope/hub/commit_scheduler.py
+++ b/modelscope/hub/commit_scheduler.py
@@ -6,7 +6,6 @@ import os
 import time
 import types
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass
 from io import SEEK_END, SEEK_SET, BytesIO
 from pathlib import Path
 from threading import Lock, Thread
@@ -22,16 +21,6 @@ from modelscope.utils.repo_utils import (CommitInfo, CommitOperationAdd,
 logger = get_logger()
 
 IGNORE_GIT_FOLDER_PATTERNS = ['.git', '.git/*', '*/.git', '**/.git/**']
-
-
-@dataclass(frozen=True)
-class _FileToUpload:
-    """Information about a file to upload."""
-
-    local_path: Path
-    path_in_repo: str
-    size_limit: int
-    last_modified: float
 
 
 @contextlib.contextmanager

--- a/modelscope/utils/file_utils.py
+++ b/modelscope/utils/file_utils.py
@@ -250,12 +250,16 @@ def get_file_hash(
         progress.update(final_chunk_size)
 
     elif isinstance(file_path_or_obj, io.BufferedIOBase):
-        while byte_chunk := file_path_or_obj.read(buffer_size):
-            chunk_hash_list.append(hashlib.sha256(byte_chunk).hexdigest())
-            file_hash.update(byte_chunk)
-            progress.update(len(byte_chunk))
-        file_hash = file_hash.hexdigest()
-        final_chunk_size = buffer_size
+        original_position = file_path_or_obj.tell()
+        try:
+            while byte_chunk := file_path_or_obj.read(buffer_size):
+                chunk_hash_list.append(hashlib.sha256(byte_chunk).hexdigest())
+                file_hash.update(byte_chunk)
+                progress.update(len(byte_chunk))
+            file_hash = file_hash.hexdigest()
+            final_chunk_size = buffer_size
+        finally:
+            file_path_or_obj.seek(original_position)
 
     else:
         progress.close()

--- a/modelscope/utils/repo_utils.py
+++ b/modelscope/utils/repo_utils.py
@@ -338,6 +338,7 @@ class UploadInfo:
     def from_fileobj(cls, fileobj: BinaryIO, file_hash_info: dict = None):
         file_hash_info: dict = file_hash_info or get_file_hash(fileobj)
         sample = fileobj.read(512)
+        fileobj.seek(0, os.SEEK_SET)
         return cls(
             sha256=file_hash_info['file_hash'],
             size=file_hash_info['file_size'],

--- a/tests/hub/test_commit_scheduler.py
+++ b/tests/hub/test_commit_scheduler.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+
+from modelscope.hub.commit_scheduler import CommitScheduler
+from modelscope.utils.repo_utils import CommitInfo
+
+
+class DummyHubApi:
+
+    def __init__(self):
+        self.commits = []
+
+    def create_repo(self,
+                    repo_id,
+                    token=None,
+                    repo_type=None,
+                    visibility='public',
+                    exist_ok=True,
+                    create_default_config=False):
+        return f'https://hub/{repo_id}'
+
+    def create_commit(self,
+                      repo_id,
+                      repo_type,
+                      operations,
+                      commit_message,
+                      revision=None,
+                      token=None):
+        self.commits.append((repo_id, operations))
+        return CommitInfo(
+            commit_url='',
+            commit_message=commit_message,
+            commit_description='',
+            oid='0')
+
+
+def test_commit_scheduler_push_only_changed_files(tmp_path):
+    file = tmp_path / 'data.txt'
+    file.write_text('start')
+
+    api = DummyHubApi()
+    scheduler = CommitScheduler(
+        repo_id='owner/repo', folder_path=tmp_path, every=0.001, hf_api=api)
+
+    scheduler.stop()
+    scheduler._scheduler_thread.join()
+    api.commits.clear()
+
+    file.write_text('updated')
+    commit_info = scheduler.push_to_hub()
+    assert commit_info is not None
+    assert len(api.commits) == 1
+
+    commit_info2 = scheduler.push_to_hub()
+    assert commit_info2 is None
+    assert len(api.commits) == 1
+
+    scheduler.executor.shutdown(wait=True)

--- a/tests/hub/test_commit_scheduler.py
+++ b/tests/hub/test_commit_scheduler.py
@@ -1,58 +1,592 @@
 import os
+import shutil
+import tempfile
+import time
+import unittest
+import uuid
+from io import SEEK_END
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from modelscope.hub.commit_scheduler import CommitScheduler
-from modelscope.utils.repo_utils import CommitInfo
+from modelscope.hub.api import HubApi
+from modelscope.hub.commit_scheduler import CommitScheduler, PartialFileIO
+from modelscope.hub.errors import NotExistError
+from modelscope.hub.repository import Repository
+from modelscope.utils.constant import DEFAULT_REPOSITORY_REVISION
+from modelscope.utils.repo_utils import CommitInfo, CommitOperationAdd
+from modelscope.utils.test_utils import (TEST_ACCESS_TOKEN1, TEST_MODEL_ORG,
+                                         delete_credential, test_level)
 
 
-class DummyHubApi:
+class TestCommitScheduler(unittest.TestCase):
+    """Test suite for ModelScope CommitScheduler functionality."""
 
-    def __init__(self):
-        self.commits = []
+    def setUp(self) -> None:
+        """Set up test environment with temporary directories and mock API."""
+        self.api = HubApi()
+        self.repo_name = f'test-commit-scheduler-{uuid.uuid4().hex[:8]}'
+        self.repo_id = f'{TEST_MODEL_ORG}/{self.repo_name}'
 
-    def create_repo(self,
-                    repo_id,
-                    token=None,
-                    repo_type=None,
-                    visibility='public',
-                    exist_ok=True,
-                    create_default_config=False):
-        return f'https://hub/{repo_id}'
+        # Create temporary cache directory
+        self.cache_dir = Path(tempfile.mkdtemp())
+        self.watched_folder = self.cache_dir / 'watched_folder'
+        self.watched_folder.mkdir(exist_ok=True, parents=True)
 
-    def create_commit(self,
-                      repo_id,
-                      repo_type,
-                      operations,
-                      commit_message,
-                      revision=None,
-                      token=None):
-        self.commits.append((repo_id, operations))
-        return CommitInfo(
-            commit_url='',
-            commit_message=commit_message,
+        # Initialize scheduler reference for cleanup
+        self.scheduler = None
+
+    def tearDown(self) -> None:
+        """Clean up test resources."""
+        # Stop scheduler if it exists
+        if self.scheduler is not None:
+            try:
+                self.scheduler.stop()
+            except Exception:
+                pass
+
+        # Clean up temporary directories
+        if self.cache_dir.exists():
+            shutil.rmtree(self.cache_dir, ignore_errors=True)
+
+        # Try to delete test repo (may not exist for mocked tests)
+        try:
+            if hasattr(self, 'api') and TEST_ACCESS_TOKEN1:
+                self.api.login(TEST_ACCESS_TOKEN1)
+                self.api.delete_repo(repo_id=self.repo_id, repo_type='dataset')
+        except Exception:
+            pass
+
+        delete_credential()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_invalid_folder_path_nonexistent(self) -> None:
+        """Test that CommitScheduler raises error for non-existent folder."""
+        nonexistent_path = self.cache_dir / 'nonexistent'
+
+        with self.assertRaises(ValueError) as cm:
+            CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=nonexistent_path,
+                interval=1,
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+        self.assertIn('does not exist', str(cm.exception))
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_invalid_interval(self) -> None:
+        """Test that CommitScheduler raises error for invalid interval values."""
+        # Test zero interval
+        with self.assertRaises(ValueError) as cm:
+            CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=self.watched_folder,
+                interval=0,
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+        self.assertIn('positive', str(cm.exception))
+
+        # Test negative interval
+        with self.assertRaises(ValueError) as cm:
+            CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=self.watched_folder,
+                interval=-1,
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+        self.assertIn('positive', str(cm.exception))
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_initialization_with_defaults(self) -> None:
+        """Test CommitScheduler initialization with default parameters."""
+        with patch.object(HubApi, 'create_repo') as mock_create:
+            mock_create.return_value = f'https://modelscope.cn/datasets/{self.repo_id}'
+
+            self.scheduler = CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=self.watched_folder,
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+
+            # Check default values
+            self.assertEqual(self.scheduler.repo_id, self.repo_id)
+            self.assertEqual(self.scheduler.folder_path,
+                             self.watched_folder.resolve())
+            self.assertEqual(self.scheduler.interval, 5)  # default 5 minutes
+            self.assertEqual(self.scheduler.path_in_repo, '')
+            self.assertEqual(self.scheduler.revision,
+                             DEFAULT_REPOSITORY_REVISION)
+            self.assertIsInstance(self.scheduler.last_uploaded, dict)
+
+            # Verify create_repo was called
+            mock_create.assert_called_once()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_initialization_with_custom_parameters(self) -> None:
+        """Test CommitScheduler initialization with custom parameters."""
+        custom_interval = 10
+        custom_path_in_repo = 'custom/path'
+        custom_revision = 'develop'
+        allow_patterns = ['*.txt', '*.json']
+        ignore_patterns = ['*.log', 'temp/*']
+
+        with patch.object(HubApi, 'create_repo') as mock_create:
+            mock_create.return_value = f'https://modelscope.cn/datasets/{self.repo_id}'
+
+            self.scheduler = CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=self.watched_folder,
+                interval=custom_interval,
+                path_in_repo=custom_path_in_repo,
+                revision=custom_revision,
+                allow_patterns=allow_patterns,
+                ignore_patterns=ignore_patterns,
+                private=True,
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+
+            # Check custom values
+            self.assertEqual(self.scheduler.interval, custom_interval)
+            self.assertEqual(self.scheduler.path_in_repo, custom_path_in_repo)
+            self.assertEqual(self.scheduler.revision, custom_revision)
+            self.assertEqual(self.scheduler.allow_patterns, allow_patterns)
+
+            # Check ignore patterns include git folders
+            expected_ignore = ignore_patterns + [
+                '.git', '.git/*', '*/.git', '**/.git/**'
+            ]
+            self.assertEqual(self.scheduler.ignore_patterns, expected_ignore)
+
+            # Verify create_repo was called with correct visibility
+            mock_create.assert_called_once()
+            call_args = mock_create.call_args
+            self.assertEqual(call_args.kwargs.get('visibility'), 'private')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    @patch.object(CommitScheduler, 'push_to_hub')
+    def test_mocked_scheduler_execution(self, mock_push: MagicMock) -> None:
+        """Test scheduler with mocked push_to_hub method."""
+        mock_push.return_value = CommitInfo(
+            commit_url=
+            'https://modelscope.cn/datasets/test_scheduler_unit/commit/test123',
+            commit_message='Test commit',
             commit_description='',
-            oid='0')
+            oid='test123')
+
+        with patch.object(HubApi, 'create_repo'):
+            self.scheduler = CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=self.watched_folder,
+                interval=1 / 60 / 10,  # every 0.1s for fast testing
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+
+            # Wait for at least a couple of scheduler cycles
+            time.sleep(0.5)
+
+            # Should have been called multiple times
+            self.assertGreater(len(mock_push.call_args_list), 1)
+
+            # Check the last future result
+            if hasattr(self.scheduler,
+                       'last_future') and self.scheduler.last_future:
+                result = self.scheduler.last_future.result()
+                self.assertEqual(result.oid, 'test123')
+                self.assertEqual(result.commit_message, 'Test commit')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_scheduler_stop(self) -> None:
+        """Test stopping the scheduler."""
+        with patch.object(HubApi, 'create_repo'):
+            self.scheduler = CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=self.watched_folder,
+                interval=1,  # 1 minute
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+
+            # Scheduler should be running
+            self.assertFalse(self.scheduler._CommitScheduler__stopped)
+
+            # Stop the scheduler
+            self.scheduler.stop()
+
+            # Scheduler should be stopped
+            self.assertTrue(self.scheduler._CommitScheduler__stopped)
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_context_manager(self) -> None:
+        """Test CommitScheduler as context manager."""
+        file_path = self.watched_folder / 'test_file.txt'
+
+        with patch.object(HubApi, 'create_repo'), \
+             patch.object(CommitScheduler, 'push_to_hub') as mock_push:
+            mock_push.return_value = CommitInfo(
+                commit_url=
+                'https://modelscope.cn/datasets/test_scheduler_unit/commit/test123',
+                commit_message='Test commit',
+                commit_description='',
+                oid='test123')
+
+            with CommitScheduler(
+                    repo_id=self.repo_id,
+                    folder_path=self.watched_folder,
+                    interval=5,  # 5 minutes - won't trigger during test
+                    hub_api=self.api,
+                    repo_type='dataset',
+                    token=TEST_ACCESS_TOKEN1) as scheduler:
+                # Write a file inside the context
+                file_path.write_text('test content')
+
+                # Reference for later assertions
+                self.scheduler = scheduler
+
+            # After exiting context, scheduler should be stopped
+            self.assertTrue(self.scheduler._CommitScheduler__stopped)
+
+            # Should have triggered push_to_hub on exit
+            mock_push.assert_called()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_trigger_manual_commit(self) -> None:
+        """Test manually triggering a commit."""
+        with patch.object(HubApi, 'create_repo'), \
+             patch.object(CommitScheduler, 'push_to_hub') as mock_push:
+            mock_push.return_value = CommitInfo(
+                commit_url=
+                'https://modelscope.cn/datasets/test_scheduler_unit/commit/test123',
+                commit_message='Manual commit',
+                commit_description='',
+                oid='manual123')
+
+            self.scheduler = CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=self.watched_folder,
+                interval=60,  # Long interval to avoid auto-trigger
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+            future = self.scheduler.trigger()
+            result = future.result()
+
+            # Verify the result
+            self.assertEqual(result.oid, 'manual123')
+            self.assertEqual(result.commit_message, 'Manual commit')
+            mock_push.assert_called()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_stopped_scheduler_no_push(self) -> None:
+        """Test that stopped scheduler doesn't perform push operations."""
+        with patch.object(HubApi, 'create_repo'):
+
+            self.scheduler = CommitScheduler(
+                repo_id=self.repo_id,
+                folder_path=self.watched_folder,
+                interval=60,
+                hub_api=self.api,
+                repo_type='dataset',
+                token=TEST_ACCESS_TOKEN1)
+
+            # Stop the scheduler immediately
+            self.scheduler.stop()
+
+            # Try to trigger after stopping
+            future = self.scheduler.trigger()
+            result = future.result()
+
+            # Result should be None for stopped scheduler
+            self.assertIsNone(result)
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_sync_local_folder_to_hub(self) -> None:
+        """Test sync local folder to remote repo."""
+        hub_cache = self.cache_dir / 'hub'
+        file_path = self.watched_folder / 'file.txt'
+        bin_path = self.watched_folder / 'file.bin'
+        git_path = self.watched_folder / '.git'
+        self.scheduler = CommitScheduler(
+            folder_path=self.watched_folder,
+            repo_id=self.repo_id,
+            interval=1 / 60,
+            hub_api=self.api,
+            repo_type='dataset',
+            token=TEST_ACCESS_TOKEN1)
+
+        # 1 push to hub triggered (empty commit not pushed)
+        time.sleep(0.5)
+
+        # write content to files
+        with file_path.open('a') as f:
+            f.write('first line\n')
+        with bin_path.open('a') as f:
+            f.write('binary content')
+        with git_path.open('a') as f:
+            f.write('git content\n')
+
+        # 2 push to hub triggered (1 commit + 1 ignored)
+        time.sleep(2)
+        self.scheduler.last_future.result()
+
+        # new content in file
+        with file_path.open('a') as f:
+            f.write('second line\n')
+
+        # 1 push to hub triggered (1 commit)
+        time.sleep(1)
+        self.scheduler.last_future.result()
+
+        with bin_path.open('a') as f:
+            f.write(' updated')
+
+        # 5 push to hub triggered (1 commit)
+        time.sleep(5)  # wait for every threads/uploads to complete
+        self.scheduler.stop()
+        self.scheduler.last_future.result()
+
+        # wait for 20 seconds for repository to be updated
+        time.sleep(20)
+
+        # 4 commits expected (initial commit + 3 push to hub)
+        repo_id = self.scheduler.repo_id
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = Repository(
+                model_dir=tmp_dir,
+                clone_from=f'{self.scheduler.repo_type}s/{repo_id}',
+                auth_token=TEST_ACCESS_TOKEN1)
+            git_wrapper = repo.git_wrapper
+            log_args = ['-C', tmp_dir, 'log', '--format=%H']
+            response = git_wrapper._run_git_command(*log_args)
+            commits = response.stdout.decode('utf8').strip().split('\n')
+
+            # Get last commit message
+            last_commit = commits[0]
+            msg_args = ['-C', tmp_dir, 'log', '-1', '--format=%B', last_commit]
+            msg_response = git_wrapper._run_git_command(*msg_args)
+            last_msg = msg_response.stdout.decode('utf8').strip()
+
+            # Exclude dataset_infos.json commit if present
+            commit_count = len(commits)
+            if 'dataset_infos.json' in last_msg:
+                commit_count -= 1
+                commits = commits[1:]  # Remove the dataset_infos commit
+
+            self.assertEqual(commit_count, 4)
+
+        def _download(filename: str, revision: str) -> Path:
+            from modelscope.hub.file_download import _repo_file_download
+            return Path(
+                _repo_file_download(
+                    repo_id=repo_id,
+                    file_path=filename,
+                    revision=revision,
+                    cache_dir=hub_cache,
+                    repo_type='dataset'))
+
+        # Check file.txt consistency
+        txt_push = _download(filename='file.txt', revision='master')
+        self.assertEqual(txt_push.read_text(), 'first line\nsecond line\n')
+
+        # Check file.bin consistency
+        bin_push = _download(filename='file.bin', revision='master')
+        self.assertEqual(bin_push.read_text(), 'binary content updated')
+
+        # Check .git file was not uploaded (should be ignored)
+        with self.assertRaises(NotExistError):
+            _download(filename='.git', revision='master')
 
 
-def test_commit_scheduler_push_only_changed_files(tmp_path):
-    file = tmp_path / 'data.txt'
-    file.write_text('start')
+class TestPartialFileIO(unittest.TestCase):
+    """Test suite for PartialFileIO functionality."""
 
-    api = DummyHubApi()
-    scheduler = CommitScheduler(
-        repo_id='owner/repo', folder_path=tmp_path, every=0.001, hf_api=api)
+    def setUp(self) -> None:
+        """Set up test environment with temporary file."""
+        self.cache_dir = Path(tempfile.mkdtemp())
+        self.test_file = self.cache_dir / 'file.txt'
+        self.test_file.write_text('123456789abcdef')  # 15 bytes
 
-    scheduler.stop()
-    scheduler._scheduler_thread.join()
-    api.commits.clear()
+    def tearDown(self) -> None:
+        """Clean up test resources."""
+        if self.cache_dir.exists():
+            shutil.rmtree(self.cache_dir, ignore_errors=True)
 
-    file.write_text('updated')
-    commit_info = scheduler.push_to_hub()
-    assert commit_info is not None
-    assert len(api.commits) == 1
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_partial_file_read_with_limit(self) -> None:
+        """Test reading partial file with size limit."""
+        partial_file = PartialFileIO(self.test_file, size_limit=5)
 
-    commit_info2 = scheduler.push_to_hub()
-    assert commit_info2 is None
-    assert len(api.commits) == 1
+        # Should read only first 5 bytes
+        content = partial_file.read()
+        self.assertEqual(content, b'12345')
 
-    scheduler.executor.shutdown(wait=True)
+        # Second read should return empty
+        content = partial_file.read()
+        self.assertEqual(content, b'')
+
+        partial_file.close()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_partial_file_read_by_chunks(self) -> None:
+        """Test reading partial file in chunks."""
+        partial_file = PartialFileIO(self.test_file, size_limit=8)
+
+        # Read in chunks
+        chunk1 = partial_file.read(3)
+        self.assertEqual(chunk1, b'123')
+
+        chunk2 = partial_file.read(3)
+        self.assertEqual(chunk2, b'456')
+
+        chunk3 = partial_file.read(3)
+        self.assertEqual(chunk3, b'78')  # Only 2 bytes left within limit
+
+        chunk4 = partial_file.read(3)
+        self.assertEqual(chunk4, b'')  # Nothing left
+
+        partial_file.close()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_partial_file_read_oversized_chunk(self) -> None:
+        """Test reading more than size limit in one go."""
+        partial_file = PartialFileIO(self.test_file, size_limit=5)
+
+        # Request more than limit
+        content = partial_file.read(20)
+        self.assertEqual(content, b'12345')  # Should return only up to limit
+
+        partial_file.close()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_partial_file_len(self) -> None:
+        """Test __len__ method returns correct size limit."""
+        partial_file = PartialFileIO(self.test_file, size_limit=7)
+        self.assertEqual(len(partial_file), 7)
+        partial_file.close()
+
+        # Size limit larger than actual file should be capped
+        large_partial = PartialFileIO(self.test_file, size_limit=100)
+        self.assertEqual(len(large_partial), 15)  # Actual file size
+        large_partial.close()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_partial_file_seek_and_tell(self) -> None:
+        """Test seek and tell operations."""
+        partial_file = PartialFileIO(self.test_file, size_limit=10)
+
+        # Initial position
+        self.assertEqual(partial_file.tell(), 0)
+
+        # Read some bytes
+        partial_file.read(3)
+        self.assertEqual(partial_file.tell(), 3)
+
+        # Seek to beginning
+        partial_file.seek(0)
+        self.assertEqual(partial_file.tell(), 0)
+
+        # Seek to specific position
+        partial_file.seek(5)
+        self.assertEqual(partial_file.tell(), 5)
+
+        # Seek beyond limit should be capped
+        partial_file.seek(50)
+        self.assertEqual(partial_file.tell(), 10)  # Capped at size limit
+
+        # Seek from end
+        partial_file.seek(-2, SEEK_END)
+        self.assertEqual(partial_file.tell(), 8)  # 10-2
+
+        partial_file.close()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_partial_file_not_implemented_methods(self) -> None:
+        """Test that unsupported methods raise NotImplementedError."""
+        partial_file = PartialFileIO(self.test_file, size_limit=5)
+
+        # These methods should not be implemented
+        with self.assertRaises(NotImplementedError):
+            partial_file.readline()
+
+        with self.assertRaises(NotImplementedError):
+            partial_file.write(b'test')
+
+        partial_file.close()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_partial_file_repr(self) -> None:
+        """Test string representation of PartialFileIO."""
+        partial_file = PartialFileIO(self.test_file, size_limit=5)
+        repr_str = repr(partial_file)
+
+        self.assertEqual(
+            repr_str,
+            f'<PartialFileIO file_path={self.test_file} size_limit=5>')
+
+        partial_file.close()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_file_modification_after_creation(self) -> None:
+        """Test that file modifications after PartialFileIO creation don't affect size limit."""
+        partial_file = PartialFileIO(self.test_file, size_limit=20)
+
+        # Original length is capped at file size
+        self.assertEqual(len(partial_file), 15)
+
+        with self.test_file.open('ab') as f:
+            f.write(b'additional_content')
+
+        # Size limit should remain the same (captured at creation)
+        self.assertEqual(len(partial_file), 15)
+
+        # Content read should still be limited to original size
+        content = partial_file.read()
+        self.assertEqual(len(content), 15)
+        self.assertEqual(content, b'123456789abcdef')
+
+        partial_file.close()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_high_size_limit(self) -> None:
+        """Test size limit larger than file size."""
+        file = PartialFileIO(self.test_file, size_limit=20)
+        with self.test_file.open('ab') as f:
+            f.write(b'ghijkl')
+
+        # File size limit is truncated to the actual file size at instance creation (not on the fly)
+        self.assertEqual(len(file), 15)
+        self.assertEqual(file._size_limit, 15)
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_with_commit_operation_add(self) -> None:
+        """Test with CommitOperationAdd."""
+        op_truncated = CommitOperationAdd(
+            path_or_fileobj=PartialFileIO(self.test_file, size_limit=5),
+            path_in_repo='test_file.txt')
+        self.assertEqual(op_truncated.upload_info.size, 5)
+        self.assertEqual(op_truncated.upload_info.sample, b'12345')
+
+        with op_truncated.as_file() as f:
+            self.assertEqual(f.read(), b'12345')
+
+        # Full file
+        op_full = CommitOperationAdd(
+            path_or_fileobj=PartialFileIO(self.test_file, size_limit=9),
+            path_in_repo='test_file.txt')
+        self.assertEqual(op_full.upload_info.size, 9)
+        self.assertEqual(op_full.upload_info.sample, b'123456789')
+
+        with op_full.as_file() as f:
+            self.assertEqual(f.read(), b'123456789')
+
+        # Truncated file has a different hash than the full file
+        self.assertNotEqual(op_truncated.upload_info.sha256,
+                            op_full.upload_info.sha256)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/hub/test_commit_scheduler.py
+++ b/tests/hub/test_commit_scheduler.py
@@ -167,9 +167,9 @@ class TestCommitScheduler(unittest.TestCase):
             self.assertEqual(call_args.kwargs.get('visibility'), 'private')
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
-    @patch.object(CommitScheduler, 'push_to_hub')
+    @patch.object(CommitScheduler, 'commit_scheduled_changes')
     def test_mocked_scheduler_execution(self, mock_push: MagicMock) -> None:
-        """Test scheduler with mocked push_to_hub method."""
+        """Test scheduler with mocked commit_scheduled_changes method."""
         mock_push.return_value = CommitInfo(
             commit_url=
             'https://modelscope.cn/datasets/test_scheduler_unit/commit/test123',
@@ -226,7 +226,7 @@ class TestCommitScheduler(unittest.TestCase):
         file_path = self.watched_folder / 'test_file.txt'
 
         with patch.object(HubApi, 'create_repo'), \
-             patch.object(CommitScheduler, 'push_to_hub') as mock_push:
+             patch.object(CommitScheduler, 'commit_scheduled_changes') as mock_push:
             mock_push.return_value = CommitInfo(
                 commit_url=
                 'https://modelscope.cn/datasets/test_scheduler_unit/commit/test123',
@@ -250,14 +250,14 @@ class TestCommitScheduler(unittest.TestCase):
             # After exiting context, scheduler should be stopped
             self.assertTrue(self.scheduler._CommitScheduler__stopped)
 
-            # Should have triggered push_to_hub on exit
+            # Should have triggered commit_scheduled_changes on exit
             mock_push.assert_called()
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_trigger_manual_commit(self) -> None:
         """Test manually triggering a commit."""
         with patch.object(HubApi, 'create_repo'), \
-             patch.object(CommitScheduler, 'push_to_hub') as mock_push:
+             patch.object(CommitScheduler, 'commit_scheduled_changes') as mock_push:
             mock_push.return_value = CommitInfo(
                 commit_url=
                 'https://modelscope.cn/datasets/test_scheduler_unit/commit/test123',
@@ -329,7 +329,7 @@ class TestCommitScheduler(unittest.TestCase):
         with git_path.open('a') as f:
             f.write('git content\n')
 
-        # 2 push to hub triggered (1 commit + 1 ignored)
+        # 2 push to hub triggered (2 commit + 1 ignored)
         time.sleep(2)
         self.scheduler.last_future.result()
 
@@ -376,7 +376,7 @@ class TestCommitScheduler(unittest.TestCase):
                 commit_count -= 1
                 commits = commits[1:]  # Remove the dataset_infos commit
 
-            self.assertEqual(commit_count, 4)
+            self.assertEqual(commit_count, 5)
 
         def _download(filename: str, revision: str) -> Path:
             from modelscope.hub.file_download import _repo_file_download


### PR DESCRIPTION
1. Add CommitScheduler (modelscope/hub/commit_scheduler.py) to schedule incremental uploads of a local folder to ModelScope Hub; depends on HubApi.upload_folder for the actual transfer and includes background scheduling, file-change detection, and context-manager support.
2. Introduce PartialFileIO to support incremental, read-only file streaming and prevent inconsistencies if files are modified during upload.
3. Update get_file_hash (modelscope/utils/file_utils.py) and from_fileobj (modelscope/utils/repo_utils.py) to restore the original file pointer after reading, preventing side effects in incremental uploads.