### PR TITLE
Fix TensorRT parse failure for MossFormer2 ONNX Squeeze axes

### DIFF
--- a/modelscope/models/audio/separation/m2/fsmn.py
+++ b/modelscope/models/audio/separation/m2/fsmn.py
@@ -141,4 +141,4 @@ class UniDeepFsmnDilated(nn.Module):
         out = self.conv(x_per)
         out1 = out.permute(0, 3, 2, 1)
 
-        return input + out1.squeeze()
+        return input + out1.squeeze(dim=1)


### PR DESCRIPTION
**Summary**
This PR fixes MossFormer2 ONNX→TensorRT conversion failure caused by an ONNX Squeeze node with implicit axes under dynamic shapes.

**What changed**
In `modelscope/models/audio/separation/m2/fsmn.py (UniDeepFsmnDilated.forward)`, replace:
`input + out1.squeeze()`
with:
`input + out1.squeeze(dim=1)`

**Why**
When exporting MossFormer2 to ONNX with dynamic shapes (e.g., dynamic time dimension), squeeze() may be exported without explicit axes. TensorRT cannot infer which dimension to squeeze from a dynamic shape and fails with:
`UNSUPPORTED_NODE_DYNAMIC: Cannot infer squeeze dimensions from a dynamic shape.`

Using squeeze(dim=1) makes the ONNX Squeeze axes explicit (axes=[1]), unblocking ONNX→TensorRT parsing.

**Behavior impact**
No intended behavior change: out1 is expected to be shaped [B, 1, T, C], so squeezing dim=1 is the correct/explicit operation.

**Fixes:** #1576

@yingdachen @tastelikefeet 