### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/modelscope/fileio/format/jsonplus.py
+++ b/modelscope/fileio/format/jsonplus.py
@@ -456,7 +456,7 @@ def _load_currency(val):
     from moneyed import get_currency
     try:
         return get_currency(code=val)
-    except:
+    except Exception:
         return Currency(**val)
 
 

--- a/modelscope/models/cv/dense_optical_flow_estimation/core/raft.py
+++ b/modelscope/models/cv/dense_optical_flow_estimation/core/raft.py
@@ -17,7 +17,7 @@ autocast = torch.cuda.amp.autocast
 
 # try:
 #     autocast = torch.cuda.amp.autocast
-# except:
+# except Exception:
 #     # dummy autocast for PyTorch < 1.6
 #     class autocast:
 #         def __init__(self, enabled):

--- a/modelscope/models/nlp/palm_v2/text_generation.py
+++ b/modelscope/models/nlp/palm_v2/text_generation.py
@@ -793,7 +793,7 @@ class Translator(object):
         '''
         try:
             query_id = batch.query_id
-        except:
+        except Exception:
             query_id = None
         '''
         translations = []


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` to avoid catching KeyboardInterrupt/SystemExit.