### PR TITLE
[Bugfix] Make `local_files_only` configurable

### DIFF
--- a/modelscope/utils/hf_util/patcher.py
+++ b/modelscope/utils/hf_util/patcher.py
@@ -180,9 +180,11 @@ def _patch_pretrained_class(all_imported_modules, wrap=False):
                 revision = 'master'
             if file_filter is not None:
                 allow_file_pattern = file_filter
+            local_files_only = kwargs.pop('local_files_only', False)
             model_dir = snapshot_download(
                 pretrained_model_name_or_path,
                 revision=revision,
+                local_files_only=local_files_only,
                 ignore_file_pattern=ignore_file_pattern,
                 allow_file_pattern=allow_file_pattern)
             if subfolder:


### PR DESCRIPTION
There exist a scenario:
```python
from transformers import PretrainedConfig
import huggingface_hub
from modelscope.utils.hf_util import patch_hub

patch_hub()

model="Qwen/Qwen3-0.6B"
kwargs = {}


config_dict, _ = PretrainedConfig.get_config_dict(
    model,
    trust_remote_code=True,
    local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
    **kwargs,
)

print(config_dict)
```
the arg `local_files_only` does work, this patch make it configurable