### PR TITLE
update ascend dockerfile

### DIFF
--- a/docker/Dockerfile.ascend
+++ b/docker/Dockerfile.ascend
@@ -106,7 +106,7 @@ fi
 ARG CUR_TIME={cur_time}
 RUN echo $CUR_TIME
 
-RUN pip install --no-cache-dir cmake
+RUN pip install --no-cache-dir --no-build-isolation OpenCC
 
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \

--- a/docker/Dockerfile.ascend
+++ b/docker/Dockerfile.ascend
@@ -1,14 +1,13 @@
 FROM {base_image}
 
-# Use bash so that `source` and other bash builtins work in all following RUN steps.
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_DEFAULT_TIMEOUT=300 \
+    PIP_RETRIES=10 \
+    SOC_VERSION={soc_version}
+
 SHELL ["/bin/bash", "-c"]
 
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-ENV PIP_DEFAULT_TIMEOUT=300
-ENV PIP_RETRIES=10
-ENV TRANSFORMERS_VERBOSITY=error
-ENV TRANSFORMERS_NO_ADVISORY_WARNINGS=1
-
+# ---------- System dependencies ----------
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
     find /etc/apt/apt.conf.d -maxdepth 1 -type f | xargs -r grep -l "APT::Update::Post-Invoke\|docker-clean" | xargs -r rm -f && \
     apt-get update -y && \
@@ -19,23 +18,55 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple && \
-    pip config set install.trusted-host mirrors.aliyun.com
+    pip config set install.trusted-host mirrors.aliyun.com && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        pip config set global.extra-index-url "https://download.pytorch.org/whl/cpu/"; \
+    fi
 
 {extra_content}
 
-# Reuse the vllm-ascend base image and only add the extra repos we need.
-# --depth 1 keeps the image smaller; branch/tag names work with shallow clone.
+# ---------- Install vllm + vllm-ascend ----------
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \
+    pip install --no-cache-dir vllm==0.18.0 && \
+    pip install --no-cache-dir \
+        --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/simple \
+        vllm-ascend==0.18.0rc1
+
+# ---------- Clone training-side repositories ----------
 RUN git clone --depth 1 --branch v0.15.3 https://github.com/NVIDIA/Megatron-LM.git /Megatron-LM && \
     git clone --depth 1 --branch core_r0.15.3 https://gitcode.com/Ascend/MindSpeed.git /MindSpeed && \
     GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 -b {swift_branch} --single-branch https://github.com/modelscope/ms-swift.git /ms-swift && \
     git clone --depth 1 https://github.com/modelscope/mcore-bridge.git /mcore-bridge
 
+# ---------- Install training-side repositories ----------
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \
     cd /MindSpeed && pip install --no-cache-dir -e . && \
     cd /mcore-bridge && pip install --no-cache-dir -e . && \
-    pip cache purge
+    cd /ms-swift && pip install --no-cache-dir -e .
 
+# ---------- Pin torch to the correct version + torch_npu ----------
+# x86: must force-install the CPU build from pytorch.org/whl/cpu
+# aarch64: PyPI only provides the CPU build, so install it directly from the Aliyun mirror
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        pip install --no-cache-dir --force-reinstall --no-deps \
+            --index-url https://download.pytorch.org/whl/cpu \
+            torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1; \
+    else \
+        pip install --no-cache-dir --force-reinstall --no-deps \
+            torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1; \
+    fi && \
+    pip install --no-cache-dir --force-reinstall --no-deps \
+        torch_npu==2.7.1.post2 && \
+    rm -rf /root/.cache/pip
+
+# ---------- Remove CUDA-only dependencies pulled in by vllm (they cause missing libtorch_cuda.so errors on NPU) ----------
+RUN pip uninstall -y flashinfer tvm-ffi torch-c-dlpack-ext 2>/dev/null || true
 ARG INSTALL_MS_DEPS={install_ms_deps}
 
 ENV MEGATRON_LM_PATH=/Megatron-LM

--- a/docker/Dockerfile.ascend
+++ b/docker/Dockerfile.ascend
@@ -39,7 +39,7 @@ RUN ARCH=$(uname -m) && \
     # Install vllm
     cd vllm && VLLM_TARGET_DEVICE=empty pip install -v -e . && cd .. && \
     # Install vllm-ascend
-    cd vllm-ascend && pip install -v -e . && cd .. 
+    cd vllm-ascend && pip install -v -e . && cd ..
 
 # ---------- Clone training-side repositories ----------
 RUN git clone --depth 1 --branch v0.15.3 https://github.com/NVIDIA/Megatron-LM.git /Megatron-LM && \

--- a/docker/Dockerfile.ascend
+++ b/docker/Dockerfile.ascend
@@ -25,14 +25,21 @@ RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple && \
     fi
 
 {extra_content}
-
 # ---------- Install vllm + vllm-ascend ----------
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \
-    pip install --no-cache-dir vllm==0.18.0 && \
-    pip install --no-cache-dir \
-        --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/simple \
-        vllm-ascend==0.18.0rc1
+    git clone --depth 1 --branch v0.14.0 https://github.com/vllm-project/vllm && \
+    git clone --depth 1 --branch v0.14.0rc1 https://github.com/vllm-project/vllm-ascend.git
+
+RUN ARCH=$(uname -m) && \
+    source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    # Install torch & torch_npu & torchvision
+    pip install torch==2.9.0 torch_npu==2.9.0 torchvision==0.24.0 && \
+    # Install vllm
+    cd vllm && VLLM_TARGET_DEVICE=empty pip install -v -e . && cd .. && \
+    # Install vllm-ascend
+    cd vllm-ascend && pip install -v -e . && cd .. 
 
 # ---------- Clone training-side repositories ----------
 RUN git clone --depth 1 --branch v0.15.3 https://github.com/NVIDIA/Megatron-LM.git /Megatron-LM && \
@@ -56,13 +63,13 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     if [ "$ARCH" = "x86_64" ]; then \
         pip install --no-cache-dir --force-reinstall --no-deps \
             --index-url https://download.pytorch.org/whl/cpu \
-            torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1; \
+            torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0; \
     else \
         pip install --no-cache-dir --force-reinstall --no-deps \
-            torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1; \
+            torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0; \
     fi && \
     pip install --no-cache-dir --force-reinstall --no-deps \
-        torch_npu==2.7.1.post2 && \
+        torch_npu==2.9.0 && \
     rm -rf /root/.cache/pip
 
 # ---------- Remove CUDA-only dependencies pulled in by vllm (they cause missing libtorch_cuda.so errors on NPU) ----------

--- a/docker/Dockerfile.ascend
+++ b/docker/Dockerfile.ascend
@@ -1,64 +1,51 @@
 FROM {base_image}
 
+# Use bash so that `source` and other bash builtins work in all following RUN steps.
+SHELL ["/bin/bash", "-c"]
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_DEFAULT_TIMEOUT=300
+ENV PIP_RETRIES=10
+ENV TRANSFORMERS_VERBOSITY=error
+ENV TRANSFORMERS_NO_ADVISORY_WARNINGS=1
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    find /etc/apt/apt.conf.d -maxdepth 1 -type f | xargs -r grep -l "APT::Update::Post-Invoke\|docker-clean" | xargs -r rm -f && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        gcc g++ cmake ninja-build libnuma-dev libgl1 libglib2.0-0 libsm6 libxext6 libxrender1 \
+        wget git curl jq vim build-essential ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple && \
     pip config set install.trusted-host mirrors.aliyun.com
 
-# Prepare required system dependencies
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends gcc g++ cmake libnuma-dev wget git curl jq vim build-essential && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    pip install --upgrade pip setuptools packaging && \
-    pip cache purge
-
 {extra_content}
 
-# Prepare repositories with low update frequency
-RUN ARCH=$(uname -m) && \
-    # Set extra pip index for x86_64 platform
-    echo "[LOG INFO] Detected architecture: $ARCH" && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        pip config set global.extra-index-url "https://download.pytorch.org/whl/cpu/"; \
-    fi && \
-    # Clone libs
-    git clone --depth 1 --branch v0.11.0 https://github.com/vllm-project/vllm && \
-    git clone --depth 1 --branch v0.11.0rc1 https://github.com/vllm-project/vllm-ascend.git && \
-    git clone https://gitcode.com/Ascend/MindSpeed.git && \
-    cd MindSpeed && git checkout f2b0977e && cd .. && \
-    git clone --depth 1 --branch core_v0.12.1 https://github.com/NVIDIA/Megatron-LM.git
+# Reuse the vllm-ascend base image and only add the extra repos we need.
+# --depth 1 keeps the image smaller; branch/tag names work with shallow clone.
+RUN git clone --depth 1 --branch v0.15.3 https://github.com/NVIDIA/Megatron-LM.git /Megatron-LM && \
+    git clone --depth 1 --branch core_r0.15.3 https://gitcode.com/Ascend/MindSpeed.git /MindSpeed && \
+    GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 -b {swift_branch} --single-branch https://github.com/modelscope/ms-swift.git /ms-swift && \
+    git clone --depth 1 https://github.com/modelscope/mcore-bridge.git /mcore-bridge
 
-# Install repositories with low update frequency
-RUN ARCH=$(uname -m) && \
-    # Export and source env
-    if [ "$ARCH" = "aarch64" ]; then \
-        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/8.3.RC1/aarch64-linux/devlib/linux/aarch64:$LD_LIBRARY_PATH; \
-    elif [ "$ARCH" = "x86_64" ]; then \
-        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/8.3.RC1/x86_64-linux/devlib/linux/x86_64/:$LD_LIBRARY_PATH; \
-    fi && \
-    source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    # Install torch & torch_npu & torchvision
-    pip install torch==2.7.1 torch_npu==2.7.1 torchvision==0.22.1 && \
-    # Install vllm
-    cd vllm && VLLM_TARGET_DEVICE=empty pip install -v -e . && cd .. && \
-    # Install vllm-ascend
-    cd vllm-ascend && pip install -v -e . && cd .. && \
-    # Install MindSpeed & Megatron
-    pip install -e MindSpeed && \
-    # Clear extra files
-    rm -rf /tmp/* /var/tmp/* && \
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \
+    cd /MindSpeed && pip install --no-cache-dir -e . && \
+    cd /mcore-bridge && pip install --no-cache-dir -e . && \
     pip cache purge
-
-ENV PYTHONPATH ${PYTHONPATH}:/Megatron-LM
 
 ARG INSTALL_MS_DEPS={install_ms_deps}
 
+ENV MEGATRON_LM_PATH=/Megatron-LM
+ENV PYTHONPATH=/Megatron-LM:${PYTHONPATH}
 # install dependencies
 COPY requirements /var/modelscope
 
-RUN pip uninstall ms-swift modelscope -y && pip --no-cache-dir install pip==23.* -U && \
+RUN pip uninstall ms-swift modelscope -y && pip install --no-cache-dir pip==23.* -U && \
 if [ "$INSTALL_MS_DEPS" = "True" ]; then \
-    pip --no-cache-dir install omegaconf==2.0.6 && \
+    pip install --no-cache-dir omegaconf==2.0.6 && \
     pip install 'editdistance==0.8.1' && \
     pip install --no-cache-dir 'cython<=0.29.36' versioneer 'numpy<2.0' && \
     pip install --no-cache-dir -r /var/modelscope/framework.txt && \
@@ -68,7 +55,7 @@ if [ "$INSTALL_MS_DEPS" = "True" ]; then \
     pip install --no-cache-dir https://modelscope.oss-cn-beijing.aliyuncs.com/packages/imageio_ffmpeg-0.4.9-py3-none-any.whl --no-dependencies --force && \
     pip install --no-cache-dir 'scipy<1.13.0' && \
     pip install --no-cache-dir funtextprocessing typeguard==2.13.3 scikit-learn && \
-    pip install --no-cache-dir decord>=0.6.0 mpi4py paint_ldm ipykernel fasttext && \
+    pip install --no-cache-dir 'decord>=0.6.0' mpi4py paint_ldm ipykernel fasttext && \
     pip install --no-cache-dir 'blobfile>=1.0.5' && \
     pip uninstall MinDAEC -y && \
     pip install https://modelscope.oss-cn-beijing.aliyuncs.com/releases/dependencies/MinDAEC-0.0.2-py3-none-any.whl && \
@@ -81,17 +68,22 @@ fi
 ARG CUR_TIME={cur_time}
 RUN echo $CUR_TIME
 
-RUN pip install --no-cache-dir -U funasr scikit-learn && \
-    pip install --no-cache-dir -U qwen_vl_utils qwen_omni_utils librosa timm transformers accelerate peft trl safetensors && \
-    cd /tmp && GIT_LFS_SKIP_SMUDGE=1 git clone -b {swift_branch}  --single-branch https://github.com/modelscope/ms-swift.git && \
-    cd ms-swift && pip install .[llm] && \
-    pip install .[eval] && pip install evalscope -U --no-dependencies && pip install ms-agent -U --no-dependencies && \
-    cd / && rm -fr /tmp/ms-swift && pip cache purge; \
-    cd /tmp && GIT_LFS_SKIP_SMUDGE=1 git clone -b  {modelscope_branch}  --single-branch https://github.com/modelscope/modelscope.git && \
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \
+    pip install --no-cache-dir -U funasr scikit-learn && \
+    pip install --no-cache-dir -U qwen_vl_utils qwen_omni_utils librosa 'timm>=0.9.0' transformers accelerate peft trl safetensors && \
+    cd /ms-swift && pip install --no-cache-dir -e '.[llm]' && \
+    pip install --no-cache-dir -e '.[eval]' && pip install evalscope -U --no-dependencies && pip install ms-agent -U --no-dependencies && \
+    cd /tmp && GIT_LFS_SKIP_SMUDGE=1 git clone -b {modelscope_branch} --single-branch https://github.com/modelscope/modelscope.git && \
     cd modelscope && pip install . -f https://modelscope.oss-cn-beijing.aliyuncs.com/releases/repo.html && \
-    cd / && rm -fr /tmp/modelscope && pip cache purge; \
-    pip install --no-cache-dir transformers diffusers timm>=0.9.0 && pip cache purge; \
-    pip install --no-cache-dir omegaconf==2.3.0 && pip cache purge;
+    cd / && rm -fr /tmp/modelscope && \
+    pip install --no-cache-dir diffusers && \
+    pip install --no-cache-dir omegaconf==2.3.0 && \
+    pip cache purge
+
+RUN echo 'source /usr/local/Ascend/ascend-toolkit/set_env.sh' >> /root/.bashrc && \
+    echo '[ -f /usr/local/Ascend/nnal/atb/set_env.sh ] && source /usr/local/Ascend/nnal/atb/set_env.sh' >> /root/.bashrc && \
+    echo 'set +H' >> /root/.bashrc
 
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 ENV VLLM_USE_MODELSCOPE=True
@@ -100,5 +92,6 @@ ENV MODELSCOPE_CACHE=/mnt/workspace/.cache/modelscope/hub
 
 # Show install results
 RUN pip list
+WORKDIR /workspace
 
-SHELL ["/bin/bash", "-c"]
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.ascend
+++ b/docker/Dockerfile.ascend
@@ -106,6 +106,8 @@ fi
 ARG CUR_TIME={cur_time}
 RUN echo $CUR_TIME
 
+RUN pip install --no-cache-dir cmake
+
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \
     pip install --no-cache-dir -U funasr scikit-learn && \

--- a/docker/build_image.py
+++ b/docker/build_image.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import platform
 import subprocess
 from datetime import datetime
 from typing import Any
@@ -454,10 +455,48 @@ RUN pip install --no-cache-dir -U icecream soundfile pybind11 py-spy
 
 class AscendImageBuilder(StableGPUImageBuilder):
 
+    @staticmethod
+    def _normalize_arch(arch: str = None) -> str:
+        arch = arch or platform.machine()
+        arch = arch.lower()
+        arch_mapping = {
+            'x86': 'x86',
+            'x86_64': 'x86',
+            'amd64': 'x86',
+            'arm': 'arm',
+            'aarch64': 'arm',
+            'arm64': 'arm',
+        }
+        if arch not in arch_mapping:
+            raise ValueError(
+                f'Unsupported architecture: {arch}. '
+                'Please pass --arch x86 or --arch arm.'
+            )
+        return arch_mapping[arch]
+
+    @staticmethod
+    def _get_atlas_hardware(soc_version: str) -> str:
+        soc_version = soc_version.lower()
+        atlas_mapping = {
+            'ascend910b1': 'A2',
+            'ascend910_9391': 'A3',
+            'ascend310p1': '300I',
+        }
+        if soc_version.startswith('ascend950'):
+            return 'A5'
+        if soc_version not in atlas_mapping:
+            raise ValueError(
+                f'Unsupported soc_version: {soc_version}. '
+                'Supported values are ascend910b1, ascend910_9391, '
+                'ascend310p1, and values starting with ascend950.')
+        return atlas_mapping[soc_version]
+
     def init_args(self, args) -> Any:
         if not args.base_image:
             # Reuse the prebuilt vllm-ascend image to avoid rebuilding its stack.
             args.base_image = 'quay.io/ascend/cann:8.5.1-a3-ubuntu22.04-py3.11'
+        args.arch = self._normalize_arch(args.arch)
+        args.atlas_hardware = self._get_atlas_hardware(args.soc_version)
         return super().init_args(args)
 
     def generate_dockerfile(self) -> str:
@@ -478,9 +517,9 @@ RUN pip install --no-cache-dir -U icecream soundfile pybind11 py-spy
 
     def image(self) -> str:
         return (
-            f'{docker_registry}:{self.args.base_image.split(":")[-1]}-'
-            f'{self.args.soc_version}-torch2.9.0-'
-            f'{self.args.modelscope_version}-ascend-test')
+            f'{docker_registry}:{self.args.swift_branch}-'
+            f'{self.args.atlas_hardware}-{self.args.python_tag}-{self.args.arch}'
+        )
 
     def push(self):
         return 0
@@ -506,6 +545,7 @@ parser.add_argument('--modelscope_branch', type=str, default='master')
 parser.add_argument('--modelscope_version', type=str, default='9.99.0')
 parser.add_argument('--swift_branch', type=str, default='main')
 parser.add_argument('--soc_version', type=str, default='ascend910_9391')
+parser.add_argument('--arch', type=str, choices=['x86', 'arm'], default=None)
 parser.add_argument('--dry_run', type=int, default=0)
 args = parser.parse_args()
 

--- a/docker/build_image.py
+++ b/docker/build_image.py
@@ -479,7 +479,7 @@ RUN pip install --no-cache-dir -U icecream soundfile pybind11 py-spy
     def image(self) -> str:
         return (
             f'{docker_registry}:{self.args.base_image.split(":")[-1]}-'
-            f'{self.args.soc_version}-torch2.7.1-'
+            f'{self.args.soc_version}-torch2.9.0-'
             f'{self.args.modelscope_version}-ascend-test')
 
     def push(self):

--- a/docker/build_image.py
+++ b/docker/build_image.py
@@ -456,8 +456,8 @@ class AscendImageBuilder(StableGPUImageBuilder):
 
     def init_args(self, args) -> Any:
         if not args.base_image:
-            # other vision search for: https://hub.docker.com/r/ascendai/cann/tags
-            args.base_image = 'swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:8.3.rc1-a3-ubuntu22.04-py3.11'
+            # Reuse the prebuilt vllm-ascend image to avoid rebuilding its stack.
+            args.base_image = 'quay.io/ascend/vllm-ascend:v0.14.0rc1-a3'
         return super().init_args(args)
 
     def generate_dockerfile(self) -> str:

--- a/docker/build_image.py
+++ b/docker/build_image.py
@@ -475,10 +475,8 @@ class AscendImageBuilder(StableGPUImageBuilder):
             'arm64': 'arm',
         }
         if arch not in arch_mapping:
-            raise ValueError(
-                f'Unsupported architecture: {arch}. '
-                'Please pass --arch x86 or --arch arm.'
-            )
+            raise ValueError(f'Unsupported architecture: {arch}. '
+                             'Please pass --arch x86 or --arch arm.')
         return arch_mapping[arch]
 
     @staticmethod

--- a/docker/build_image.py
+++ b/docker/build_image.py
@@ -457,7 +457,7 @@ class AscendImageBuilder(StableGPUImageBuilder):
     def init_args(self, args) -> Any:
         if not args.base_image:
             # Reuse the prebuilt vllm-ascend image to avoid rebuilding its stack.
-            args.base_image = 'quay.io/ascend/vllm-ascend:v0.14.0rc1-a3'
+            args.base_image = 'quay.io/ascend/cann:8.5.1-a3-ubuntu22.04-py3.11'
         return super().init_args(args)
 
     def generate_dockerfile(self) -> str:
@@ -467,6 +467,7 @@ RUN pip install --no-cache-dir -U icecream soundfile pybind11 py-spy
         with open('docker/Dockerfile.ascend', 'r') as f:
             content = f.read()
             content = content.replace('{base_image}', self.args.base_image)
+            content = content.replace('{soc_version}', self.args.soc_version)
             content = content.replace('{extra_content}', extra_content)
             content = content.replace('{cur_time}', formatted_time)
             content = content.replace('{install_ms_deps}', 'False')
@@ -477,8 +478,9 @@ RUN pip install --no-cache-dir -U icecream soundfile pybind11 py-spy
 
     def image(self) -> str:
         return (
-            f'{docker_registry}:{self.args.base_image.split(":")[-1]}-torch2.7.1'
-            f'-{self.args.modelscope_version}-ascend-test')
+            f'{docker_registry}:{self.args.base_image.split(":")[-1]}-'
+            f'{self.args.soc_version}-torch2.7.1-'
+            f'{self.args.modelscope_version}-ascend-test')
 
     def push(self):
         return 0
@@ -503,6 +505,7 @@ parser.add_argument('--optimum_version', type=str, default=None)
 parser.add_argument('--modelscope_branch', type=str, default='master')
 parser.add_argument('--modelscope_version', type=str, default='9.99.0')
 parser.add_argument('--swift_branch', type=str, default='main')
+parser.add_argument('--soc_version', type=str, default='ascend910_9391')
 parser.add_argument('--dry_run', type=int, default=0)
 args = parser.parse_args()
 


### PR DESCRIPTION
Update the Ascend NPU Dockerfile to use the CANN base image instead of relying on the vllm-ascend image, making it easier to independently update the CANN version and the vllm-ascend version in the future.