### PR TITLE
fix: patch_context() use try/finally to ensure unpatch on exception

### DIFF
--- a/modelscope/utils/hf_util/patcher.py
+++ b/modelscope/utils/hf_util/patcher.py
@@ -1014,5 +1014,7 @@ def unpatch_hub():
 @contextlib.contextmanager
 def patch_context():
     patch_hub()
-    yield
-    unpatch_hub()
+    try:
+        yield
+    finally:
+        unpatch_hub()


### PR DESCRIPTION
- Wrapped yield in try/finally block so unpatch_hub() executes even when the with-body raises an exception, preventing patch state leakage