### PR TITLE
Fix release workflow hub dependency

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install wheel
-        run: pip install wheel && pip install -r requirements/framework.txt
+        run: |
+          pip install wheel
+          pip install -r requirements/framework.txt
+          pip install -r requirements/hub.txt
       - name: Build ModelScope
         # Build AST template before packaging
         run: |


### PR DESCRIPTION
## Summary
- install hub requirements before building the release wheel
- keep the existing framework dependency install step

## Why
The release build runs generate_ast_template before package dependencies are installed. After the Hub refactor, importing modelscope requires modelscope_hub, so the workflow must install requirements/hub.txt before make whl.

## Validation
- verified the branch diff only changes .github/workflows/publish.yaml
- pre-push hook completed successfully