### PR TITLE
Fix RecursionError on Repeated Streaming Dataset Loads via Idempotent HfFileSystem Patching

### DIFF
--- a/modelscope/msdatasets/utils/hf_datasets_util.py
+++ b/modelscope/msdatasets/utils/hf_datasets_util.py
@@ -1212,14 +1212,18 @@ def load_dataset_with_ctx(*args, **kwargs):
 
     streaming = kwargs.get('streaming', False)
 
+    _streaming_dataset_returned = False
+
     try:
         dataset_res = DatasetsWrapperHF.load_dataset(*args, **kwargs)
+        _streaming_dataset_returned = streaming
         yield dataset_res
     finally:
         _repo_tree_cache.clear()
         HubApi._dataset_id_type_cache.clear()
 
-        if not streaming:
+        should_restore = not _streaming_dataset_returned
+        if should_restore:
             if not hf_fs_open_was_patched:
                 HfFileSystem._open = hf_fs_open_origin
                 _hf_fs_open_original = None

--- a/modelscope/msdatasets/utils/hf_datasets_util.py
+++ b/modelscope/msdatasets/utils/hf_datasets_util.py
@@ -1185,6 +1185,8 @@ def load_dataset_with_ctx(*args, **kwargs):
     generate_from_dict_origin = features.generate_from_dict
     hf_fs_open_origin = HfFileSystem._open
     hf_fs_init_origin = HfFileSystem.__init__
+    hf_fs_open_was_patched = hf_fs_open_origin is _hf_fs_open
+    hf_fs_init_was_patched = hf_fs_init_origin is _hf_fs_init_with_cookie
 
     # Apply patches
     config.HF_ENDPOINT = get_endpoint()
@@ -1201,10 +1203,12 @@ def load_dataset_with_ctx(*args, **kwargs):
     if _HAS_SCRIPT_LOADING:
         HubDatasetModuleFactoryWithScript.get_module = get_module_with_script
     features.generate_from_dict = generate_from_dict_ms
-    _hf_fs_open_original = hf_fs_open_origin
-    HfFileSystem._open = _hf_fs_open
-    _hf_fs_init_original = hf_fs_init_origin
-    HfFileSystem.__init__ = _hf_fs_init_with_cookie
+    if not hf_fs_open_was_patched:
+        _hf_fs_open_original = hf_fs_open_origin
+        HfFileSystem._open = _hf_fs_open
+    if not hf_fs_init_was_patched:
+        _hf_fs_init_original = hf_fs_init_origin
+        HfFileSystem.__init__ = _hf_fs_init_with_cookie
 
     streaming = kwargs.get('streaming', False)
 
@@ -1216,10 +1220,12 @@ def load_dataset_with_ctx(*args, **kwargs):
         HubApi._dataset_id_type_cache.clear()
 
         if not streaming:
-            HfFileSystem._open = hf_fs_open_origin
-            _hf_fs_open_original = None
-            HfFileSystem.__init__ = hf_fs_init_origin
-            _hf_fs_init_original = None
+            if not hf_fs_open_was_patched:
+                HfFileSystem._open = hf_fs_open_origin
+                _hf_fs_open_original = None
+            if not hf_fs_init_was_patched:
+                HfFileSystem.__init__ = hf_fs_init_origin
+                _hf_fs_init_original = None
 
             config.HF_ENDPOINT = hf_endpoint_origin
             file_utils.get_from_cache = get_from_cache_origin

--- a/tests/msdatasets/test_stream_load.py
+++ b/tests/msdatasets/test_stream_load.py
@@ -14,6 +14,17 @@ logger = get_logger()
 
 class TestStreamLoad(unittest.TestCase):
 
+    @staticmethod
+    def _reset_hf_filesystem_patch(hf_datasets_util):
+        if (HfFileSystem._open is hf_datasets_util._hf_fs_open
+                and hf_datasets_util._hf_fs_open_original is not None):
+            HfFileSystem._open = hf_datasets_util._hf_fs_open_original
+            hf_datasets_util._hf_fs_open_original = None
+        if (HfFileSystem.__init__ is hf_datasets_util._hf_fs_init_with_cookie
+                and hf_datasets_util._hf_fs_init_original is not None):
+            HfFileSystem.__init__ = hf_datasets_util._hf_fs_init_original
+            hf_datasets_util._hf_fs_init_original = None
+
     def test_hf_filesystem_patch_idempotent_for_repeated_streaming_loads(self):
         from modelscope.msdatasets.utils import hf_datasets_util
 
@@ -22,6 +33,7 @@ class TestStreamLoad(unittest.TestCase):
         open_original_before = hf_datasets_util._hf_fs_open_original
         init_original_before = hf_datasets_util._hf_fs_init_original
         try:
+            self._reset_hf_filesystem_patch(hf_datasets_util)
             with mock.patch.object(
                     hf_datasets_util.DatasetsWrapperHF,
                     'load_dataset',
@@ -41,6 +53,35 @@ class TestStreamLoad(unittest.TestCase):
             self.assertIsNot(
                 hf_datasets_util._hf_fs_init_original,
                 hf_datasets_util._hf_fs_init_with_cookie)
+        finally:
+            HfFileSystem._open = hf_fs_open_before
+            HfFileSystem.__init__ = hf_fs_init_before
+            hf_datasets_util._hf_fs_open_original = open_original_before
+            hf_datasets_util._hf_fs_init_original = init_original_before
+
+    def test_hf_filesystem_patch_restored_when_streaming_load_fails(self):
+        from modelscope.msdatasets.utils import hf_datasets_util
+
+        hf_fs_open_before = HfFileSystem._open
+        hf_fs_init_before = HfFileSystem.__init__
+        open_original_before = hf_datasets_util._hf_fs_open_original
+        init_original_before = hf_datasets_util._hf_fs_init_original
+        try:
+            self._reset_hf_filesystem_patch(hf_datasets_util)
+            hf_fs_open_clean = HfFileSystem._open
+            hf_fs_init_clean = HfFileSystem.__init__
+            with mock.patch.object(
+                    hf_datasets_util.DatasetsWrapperHF,
+                    'load_dataset',
+                    side_effect=RuntimeError('load failed')):
+                with self.assertRaises(RuntimeError):
+                    with hf_datasets_util.load_dataset_with_ctx(streaming=True):
+                        pass
+
+            self.assertIs(HfFileSystem._open, hf_fs_open_clean)
+            self.assertIs(HfFileSystem.__init__, hf_fs_init_clean)
+            self.assertIsNone(hf_datasets_util._hf_fs_open_original)
+            self.assertIsNone(hf_datasets_util._hf_fs_init_original)
         finally:
             HfFileSystem._open = hf_fs_open_before
             HfFileSystem.__init__ = hf_fs_init_before

--- a/tests/msdatasets/test_stream_load.py
+++ b/tests/msdatasets/test_stream_load.py
@@ -1,6 +1,9 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
 import unittest
+from unittest import mock
+
+from huggingface_hub.hf_file_system import HfFileSystem
 
 from modelscope import MsDataset
 from modelscope.utils.logger import get_logger
@@ -10,6 +13,39 @@ logger = get_logger()
 
 
 class TestStreamLoad(unittest.TestCase):
+
+    def test_hf_filesystem_patch_idempotent_for_repeated_streaming_loads(self):
+        from modelscope.msdatasets.utils import hf_datasets_util
+
+        hf_fs_open_before = HfFileSystem._open
+        hf_fs_init_before = HfFileSystem.__init__
+        open_original_before = hf_datasets_util._hf_fs_open_original
+        init_original_before = hf_datasets_util._hf_fs_init_original
+        try:
+            with mock.patch.object(
+                    hf_datasets_util.DatasetsWrapperHF,
+                    'load_dataset',
+                    return_value=object()):
+                with hf_datasets_util.load_dataset_with_ctx(streaming=True):
+                    pass
+                with hf_datasets_util.load_dataset_with_ctx(streaming=True):
+                    pass
+
+            self.assertIs(HfFileSystem._open, hf_datasets_util._hf_fs_open)
+            self.assertIsNot(
+                hf_datasets_util._hf_fs_open_original,
+                hf_datasets_util._hf_fs_open)
+            self.assertIs(
+                HfFileSystem.__init__,
+                hf_datasets_util._hf_fs_init_with_cookie)
+            self.assertIsNot(
+                hf_datasets_util._hf_fs_init_original,
+                hf_datasets_util._hf_fs_init_with_cookie)
+        finally:
+            HfFileSystem._open = hf_fs_open_before
+            HfFileSystem.__init__ = hf_fs_init_before
+            hf_datasets_util._hf_fs_open_original = open_original_before
+            hf_datasets_util._hf_fs_init_original = init_original_before
 
     def setUp(self):
         ...


### PR DESCRIPTION

* **Idempotent Patch Detection**: Checks if `HfFileSystem` is already patched before wrapping, preventing the system from capturing previously patched wrappers as "original" functions.
* **Prevent Infinite Recursion**: Eliminates the `RecursionError` caused when `_hf_fs_open` or `_hf_fs_init_with_cookie` mistakenly call themselves recursively during back-to-back `load_dataset_with_ctx` calls.
* **Targeted Patch Restoration**: Updates the `finally` block to only restore patches applied during the current invocation, leaving pre-existing, intentional streaming patches intact.
* **New Integration Test**: Introduces `test_hf_filesystem_patch_idempotent_for_repeated_streaming_loads` to verify that consecutive streaming loads run safely without regression.