### PR TITLE
Fix several security issues.

### DIFF
--- a/modelscope/models/audio/tts/voice.py
+++ b/modelscope/models/audio/tts/voice.py
@@ -167,9 +167,9 @@ class Voice:
             raise TtsModelNotExistsException(
                 'modelscope error: voc model file not found')
         with open(self.am_config_path, 'r') as f:
-            self.am_config = yaml.load(f, Loader=yaml.Loader)
+            self.am_config = yaml.load(f, Loader=yaml.SafeLoader)
         with open(self.voc_config_path, 'r') as f:
-            self.voc_config = yaml.load(f, Loader=yaml.Loader)
+            self.voc_config = yaml.load(f, Loader=yaml.SafeLoader)
         if 'linguistic_unit' not in self.am_config:
             raise TtsModelConfigurationException(
                 'no linguistic_unit in am config')
@@ -366,9 +366,9 @@ class Voice:
         train_steps = hparams.get('train_steps', 0)
 
         with open(self.audio_config, 'r') as f:
-            config = yaml.load(f, Loader=yaml.Loader)
+            config = yaml.load(f, Loader=yaml.SafeLoader)
         with open(config_path, 'r') as f:
-            config.update(yaml.load(f, Loader=yaml.Loader))
+            config.update(yaml.load(f, Loader=yaml.SafeLoader))
             config.update(hparams)
 
         resume_from = None
@@ -529,10 +529,10 @@ class Voice:
         train_steps = hparams.get('train_steps', 0)
 
         with open(self.audio_config, 'r') as f:
-            config = yaml.load(f, Loader=yaml.Loader)
+            config = yaml.load(f, Loader=yaml.SafeLoader)
 
         with open(config_path, 'r') as f:
-            config.update(yaml.load(f, Loader=yaml.Loader))
+            config.update(yaml.load(f, Loader=yaml.SafeLoader))
             config.update(hparams)
 
         resume_from = None

--- a/modelscope/models/cv/controllable_image_generation/controlnet.py
+++ b/modelscope/models/cv/controllable_image_generation/controlnet.py
@@ -81,6 +81,7 @@ class ControlNet(TorchModel):
         device = kwargs.get('device', 'cuda')
         if device == 'gpu':
             device = 'cuda'
+        self.check_trust_remote_code(model_dir=model_dir)
         model = create_model(yaml_path).cpu()
         state_dict = load_state_dict(ckpt_path, location=device)
         compatible_position_ids(

--- a/modelscope/models/cv/image_paintbyexample/model.py
+++ b/modelscope/models/cv/image_paintbyexample/model.py
@@ -41,6 +41,7 @@ class StablediffusionPaintbyexample(TorchModel):
         super().__init__(model_dir, **kwargs)
 
         config = OmegaConf.load(os.path.join(model_dir, 'v1.yaml'))
+        self.check_trust_remote_code(model_dir=model_dir)
         model = load_model_from_config(
             config, os.path.join(model_dir, 'pytorch_model.pt'))
         self.model = model

--- a/modelscope/models/cv/image_view_transform/image_view_transform_infer.py
+++ b/modelscope/models/cv/image_view_transform/image_view_transform_infer.py
@@ -64,11 +64,13 @@ class ImageViewTransform(TorchModel):
         config = os.path.join(model_dir,
                               'sd-objaverse-finetune-c_concat-256.yaml')
         ckpt = os.path.join(model_dir, 'zero123-xl.ckpt')
+
+        self.check_trust_remote_code(model_dir=model_dir)
+
         config = OmegaConf.load(config)
         self.model = None
         self.model = load_model_from_config(
             self.model, config, ckpt, device=self.device)
-        self.check_trust_remote_code(model_dir=model_dir)
 
     def forward(self, model_path, x, y):
         pred_results = _infer(self.model, model_path, x, y, self.device)

--- a/modelscope/models/multi_modal/mplug/configuration_mplug.py
+++ b/modelscope/models/multi_modal/mplug/configuration_mplug.py
@@ -112,7 +112,7 @@ class MPlugConfig(PretrainedConfig):
     def from_yaml_file(cls, yaml_file: Union[str,
                                              os.PathLike]) -> Dict[str, Any]:
         with open(yaml_file, 'r', encoding='utf-8') as reader:
-            config_dict = yaml.load(reader, Loader=yaml.Loader)
+            config_dict = yaml.load(reader, Loader=yaml.SafeLoader)
         return cls(**config_dict)
 
 
@@ -176,5 +176,5 @@ class HiTeAConfig(PretrainedConfig):
     def from_yaml_file(cls, yaml_file: Union[str,
                                              os.PathLike]) -> Dict[str, Any]:
         with open(yaml_file, 'r', encoding='utf-8') as reader:
-            config_dict = yaml.load(reader, Loader=yaml.Loader)
+            config_dict = yaml.load(reader, Loader=yaml.SafeLoader)
         return cls(**config_dict)


### PR DESCRIPTION
## Security: fix multiple RCE vectors in ModelScope
This PR fixes a cluster of remote-code-execution bugs where attacker-controlled
artifacts (model repo files) were fed unchecked to create_model, load_model_from_config,
or unsafe YAML loaders.

1. Issue https://github.com/modelscope/modelscope/issues/1660 — RCE via unsafe yaml loading

- use `yaml.SafeLoader` rather than unsafe `yaml.Loader`

2. Issue https://github.com/modelscope/modelscope/issues/1659 — RCE via ImageViewTransform

- add `check_trust_remote_code()` before `load_model_from_config`. 

3. Issue https://github.com/modelscope/modelscope/issues/1758 - RCE via ControlNet and StablediffusionPaintbyexample

- add `check_trust_remote_code()` before `load_model_from_config`.
- add `check_trust_remote_code()` before `create_model`.