### PR TITLE
Add Intel XPU device support

### DIFF
--- a/modelscope/utils/constant.py
+++ b/modelscope/utils/constant.py
@@ -565,6 +565,7 @@ class Devices:
     """device used for training and inference"""
     cpu = 'cpu'
     gpu = 'gpu'
+    xpu = 'xpu'
 
 
 # Supported extensions for text datasets.

--- a/modelscope/utils/device.py
+++ b/modelscope/utils/device.py
@@ -9,22 +9,22 @@ logger = get_logger()
 
 
 def verify_device(device_name):
-    """ Verify device is valid, device should be either cpu, cuda, gpu, cuda:X or gpu:X.
+    """ Verify device is valid, device should be either cpu, cuda, gpu, xpu, cuda:X, gpu:X or xpu:X.
 
     Args:
-        device (str):  device str, should be either cpu, cuda, gpu, gpu:X or cuda:X
-            where X is the ordinal for gpu device.
+        device (str):  device str, should be either cpu, cuda, gpu, xpu, gpu:X, cuda:X or xpu:X
+            where X is the ordinal for the device.
 
     Return:
         device info (tuple):  device_type and device_id, if device_id is not set, will use 0 as default.
     """
-    err_msg = 'device should be either cpu, cuda, gpu, gpu:X or cuda:X where X is the ordinal for gpu device.'
+    err_msg = 'device should be either cpu, cuda, gpu, xpu, gpu:X, cuda:X or xpu:X where X is the ordinal for the device.'
     assert device_name is not None and device_name != '', err_msg
     device_name = device_name.lower()
     eles = device_name.split(':')
     assert len(eles) <= 2, err_msg
     assert device_name is not None
-    assert eles[0] in ['cpu', 'cuda', 'gpu'], err_msg
+    assert eles[0] in ['cpu', 'cuda', 'gpu', 'xpu'], err_msg
     device_type = eles[0]
     device_id = None
     if len(eles) > 1:
@@ -32,6 +32,8 @@ def verify_device(device_name):
     if device_type == 'cuda':
         device_type = Devices.gpu
     if device_type == Devices.gpu and device_id is None:
+        device_id = 0
+    if device_type == Devices.xpu and device_id is None:
         device_id = 0
     return device_type, device_id
 
@@ -77,6 +79,12 @@ def device_placement(framework, device_name='gpu:0'):
             else:
                 logger.debug(
                     'pytorch: cuda is not available, using cpu instead.')
+        elif device_type == Devices.xpu:
+            if hasattr(torch, 'xpu') and torch.xpu.is_available():
+                torch.xpu.set_device(f'xpu:{device_id}')
+            else:
+                logger.debug(
+                    'pytorch: xpu is not available, using cpu instead.')
         yield
     else:
         yield
@@ -86,23 +94,19 @@ def create_device(device_name):
     """ create torch device
 
     Args:
-        device_name (str):  cpu, gpu, gpu:0, cuda:0 etc.
+        device_name (str):  cpu, gpu, gpu:0, cuda:0, xpu, xpu:0 etc.
     """
     import torch
     device_type, device_id = verify_device(device_name)
-    use_cuda = False
     if device_type == Devices.gpu:
-        use_cuda = True
-        if not torch.cuda.is_available():
-            logger.info('cuda is not available, using cpu instead.')
-            use_cuda = False
-
-    if use_cuda:
-        device = torch.device(f'cuda:{device_id}')
-    else:
-        device = torch.device('cpu')
-
-    return device
+        if torch.cuda.is_available():
+            return torch.device(f'cuda:{device_id}')
+        logger.info('cuda is not available, using cpu instead.')
+    elif device_type == Devices.xpu:
+        if hasattr(torch, 'xpu') and torch.xpu.is_available():
+            return torch.device(f'xpu:{device_id}')
+        logger.info('xpu is not available, using cpu instead.')
+    return torch.device('cpu')
 
 
 def get_device():
@@ -114,6 +118,12 @@ def get_device():
             device_id = f"cuda:{os.environ['LOCAL_RANK']}"
         else:
             device_id = 'cuda:0'
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+        if dist.is_available() and dist.is_initialized(
+        ) and 'LOCAL_RANK' in os.environ:
+            device_id = f"xpu:{os.environ['LOCAL_RANK']}"
+        else:
+            device_id = 'xpu:0'
     else:
         device_id = 'cpu'
     return torch.device(device_id)

--- a/tests/utils/test_device.py
+++ b/tests/utils/test_device.py
@@ -10,7 +10,7 @@ import torch
 
 from modelscope.utils.constant import Frameworks
 from modelscope.utils.device import (create_device, device_placement,
-                                     verify_device)
+                                     get_device, verify_device)
 
 
 class DeviceTest(unittest.TestCase):
@@ -42,6 +42,14 @@ class DeviceTest(unittest.TestCase):
 
         device_name, device_id = verify_device('gpu:1')
         self.assertEqual(device_name, 'gpu')
+        self.assertTrue(device_id == 1)
+
+        device_name, device_id = verify_device('xpu')
+        self.assertEqual(device_name, 'xpu')
+        self.assertTrue(device_id == 0)
+
+        device_name, device_id = verify_device('xpu:1')
+        self.assertEqual(device_name, 'xpu')
         self.assertTrue(device_id == 1)
 
         with self.assertRaises(AssertionError):
@@ -80,6 +88,41 @@ class DeviceTest(unittest.TestCase):
         self.assertTrue(device.type == target_device_type)
         self.assertTrue(device.index == target_device_index)
 
+    def test_get_device_cpu(self):
+        if torch.cuda.is_available() or (hasattr(torch, 'xpu')
+                                         and torch.xpu.is_available()):
+            self.skipTest('accelerator present, cpu fallback not exercised')
+        device = get_device()
+        self.assertIsInstance(device, torch.device)
+        self.assertEqual(device.type, 'cpu')
+
+    @unittest.skipUnless(
+        hasattr(torch, 'xpu') and torch.xpu.is_available(), 'no xpu')
+    def test_get_device_xpu(self):
+        device = get_device()
+        self.assertIsInstance(device, torch.device)
+        self.assertEqual(device.type, 'xpu')
+
+    def test_create_device_xpu_fallback(self):
+        if hasattr(torch, 'xpu') and torch.xpu.is_available():
+            self.skipTest('xpu present, fallback not exercised')
+        device = create_device('xpu')
+        self.assertIsInstance(device, torch.device)
+        self.assertEqual(device.type, 'cpu')
+
+    @unittest.skipUnless(
+        hasattr(torch, 'xpu') and torch.xpu.is_available(), 'no xpu')
+    def test_create_device_xpu(self):
+        device = create_device('xpu')
+        self.assertIsInstance(device, torch.device)
+        self.assertEqual(device.type, 'xpu')
+        self.assertEqual(device.index, 0)
+
+        device = create_device('xpu:0')
+        self.assertIsInstance(device, torch.device)
+        self.assertEqual(device.type, 'xpu')
+        self.assertEqual(device.index, 0)
+
     def test_device_placement_cpu(self):
         with device_placement(Frameworks.torch, 'cpu'):
             pass
@@ -101,6 +144,12 @@ class DeviceTest(unittest.TestCase):
         with device_placement(Frameworks.torch, 'gpu:0'):
             if torch.cuda.is_available():
                 self.assertEqual(torch.cuda.current_device(), 0)
+
+    @unittest.skipUnless(
+        hasattr(torch, 'xpu') and torch.xpu.is_available(), 'no xpu')
+    def test_device_placement_torch_xpu(self):
+        with device_placement(Frameworks.torch, 'xpu:0'):
+            self.assertEqual(torch.xpu.current_device(), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Adds Intel XPU support (Intel GPU via `torch.xpu`) to the device utility module.
Previously, passing `xpu` to any device utility raised `AssertionError`, and
`get_device()` had no XPU branch — Intel GPU hardware silently fell back to CPU.

---

## What changed

### `modelscope/utils/constant.py`
| Before | After |
|---|---|
| `cpu`, `gpu` only | Added `xpu = 'xpu'` to `Devices` class |

### `modelscope/utils/device.py`

| Function | Change |
|---|---|
| `verify_device` | Added `'xpu'` to accepted allowlist; default `device_id = 0` for bare `'xpu'`; updated docstring |
| `create_device` | Added XPU branch → `torch.device('xpu:N')`; falls back to CPU with log warning |
| `device_placement` | Added XPU branch for PyTorch path → `torch.xpu.set_device()`; falls back silently |
| `get_device` | Extended XPU branch to respect `LOCAL_RANK` for multi-XPU distributed training |

> **Multi-XPU distributed example:** with 4 XPUs and `LOCAL_RANK` set,
> worker 0 → `xpu:0`, worker 1 → `xpu:1`, worker 2 → `xpu:2`, worker 3 → `xpu:3`

All XPU paths guarded with `hasattr(torch, 'xpu') and torch.xpu.is_available()` —
**zero impact on existing CUDA or CPU environments.**

### `tests/utils/test_device.py`

| Test | Behaviour |
|---|---|
| `test_verify` | Added `xpu` and `xpu:1` assertion cases |
| `test_get_device_xpu` | `@skipUnless` XPU available — asserts `device.type == 'xpu'` |
| `test_get_device_cpu` | Skips when accelerator present — asserts CPU fallback |
| `test_create_device_xpu` | `@skipUnless` XPU available — asserts correct `xpu:0` device |
| `test_create_device_xpu_fallback` | Skips when XPU present — asserts CPU fallback |
| `test_device_placement_torch_xpu` | `@skipUnless` XPU available — asserts `torch.xpu.current_device() == 0` |

---

## Test results

> Tested on Intel XPU hardware — `torch==2.12.0+xpu` · `xpu_count=1` · `Python 3.12.3`

<details>
<summary>▶ Click to expand full test output</summary>

platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/dut3806/sy/modelscope

tests/utils/test_device.py::DeviceTest::test_create_device_torch          PASSED   [ 10%]
tests/utils/test_device.py::DeviceTest::test_create_device_xpu            PASSED   [ 20%]
tests/utils/test_device.py::DeviceTest::test_create_device_xpu_fallback   SKIPPED  [ 30%]
tests/utils/test_device.py::DeviceTest::test_device_placement_cpu         PASSED   [ 40%]
tests/utils/test_device.py::DeviceTest::test_device_placement_tf_gpu      SKIPPED  [ 50%]
tests/utils/test_device.py::DeviceTest::test_device_placement_torch_gpu   PASSED   [ 60%]
tests/utils/test_device.py::DeviceTest::test_device_placement_torch_xpu   PASSED   [ 70%]
tests/utils/test_device.py::DeviceTest::test_get_device_cpu               SKIPPED  [ 80%]
tests/utils/test_device.py::DeviceTest::test_get_device_xpu               PASSED   [ 90%]
tests/utils/test_device.py::DeviceTest::test_verify                       PASSED   [100%]

========================= 7 passed, 3 skipped =========================



</details>

### Result breakdown

| Status | Count | Tests |
|---|---|---|
| ✅ PASSED | 7 | Includes 3 real XPU hardware assertions |
| ⏭️ SKIPPED | 3 | XPU present → fallback tests skipped; 1 pre-existing TF skip |
| ❌ FAILED | 0 | — |

> **How to read the skips:**
> - `test_create_device_xpu_fallback` and `test_get_device_cpu` are skipped *because* XPU is present — they exist to verify CPU fallback on non-XPU machines
> - On a CPU-only or CUDA machine the pattern inverts: XPU tests skip, fallback tests pass

---

## Environment requirement

> ⚠️ Standard `pip install torch` does **not** include `torch.xpu`.
> Without the XPU wheels, `hasattr(torch, 'xpu')` returns `False` and all XPU
> paths are skipped automatically — no errors, no breakage for existing users.

Install the Intel XPU wheels to enable XPU support:

```bash
pip3 install torch==2.12.0+xpu -index-url https://download.pytorch.org/whl/xpu