### PR TITLE
Support configurable source installation of mcore-bridge in Ascend Docker image

### DIFF
--- a/docker/ascend/Dockerfile.ascend
+++ b/docker/ascend/Dockerfile.ascend
@@ -92,6 +92,7 @@ RUN git clone --depth 1 --branch {vllm_ascend_git_ref} \
 # ---------- Clone training-side repositories ----------
 RUN git clone --depth 1 --branch {megatron_branch} https://github.com/NVIDIA/Megatron-LM.git /Megatron-LM && \
     git clone --depth 1 --branch {mindspeed_branch} https://gitcode.com/Ascend/MindSpeed.git /MindSpeed && \
+    git clone --depth 1 --single-branch --branch {mcore_bridge_branch} https://github.com/modelscope/mcore-bridge.git /mcore-bridge && \
     GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 -b {swift_branch} --single-branch https://github.com/modelscope/ms-swift.git /ms-swift
 
 # ---------- Install core training components ----------
@@ -100,7 +101,7 @@ RUN export PIP_EXTRA_INDEX_URL="${PIP_EXTRA_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi && \
     cd /MindSpeed && pip install --no-cache-dir -e . && \
-    pip install --no-cache-dir mcore-bridge -i https://pypi.org/simple/ -U && \
+    cd /mcore-bridge && pip install --no-cache-dir -e . && \
     pip install --no-cache-dir -U modelscope && \
     cd /ms-swift && pip install --no-cache-dir -e .
 

--- a/docker/ascend/OVERVIEW.ascend.md
+++ b/docker/ascend/OVERVIEW.ascend.md
@@ -32,7 +32,7 @@ The Ascend Dockerfile installs and configures:
 | FLA                      | source checkout from `fla-org/flash-linear-attention`, default branch `main`; configurable with `--fla_version` using a branch or release tag |
 | Megatron-LM              | source checkout, default branch `v0.15.3`; configurable with `--megatron_branch` |
 | MindSpeed                | source checkout, default branch `core_r0.15.3`; configurable with `--mindspeed_branch` |
-| mcore-bridge             | latest release from PyPI; no dedicated version option in the Ascend build entrypoint |
+| mcore-bridge             | editable source checkout from `modelscope/mcore-bridge`, default branch `main`; configurable with `--mcore_bridge_branch` using a branch or release tag |
 | ms-swift                 | source checkout from `modelscope/ms-swift`, default branch `main`; configurable with `--swift_branch` |
 | DeepSpeed                | newest package satisfying `deepspeed>=0.19`; `TORCH_DEVICE_BACKEND_AUTOLOAD=0` is scoped to its build-time install command |
 | ModelScope               | latest published package resolved by `pip install -U modelscope`; the Ascend image does not clone ModelScope or modelscope-hub source repositories |
@@ -111,7 +111,8 @@ python docker/build_image.py \
   --modelscope_branch master \
   --swift_branch v4.5.2 \
   --megatron_branch core_v0.16.0 \
-  --mindspeed_branch core_r0.16.0
+  --mindspeed_branch core_r0.16.0 \
+  --mcore_bridge_branch v1.6.2
 ```
 
 ## Custom Build Parameters
@@ -139,6 +140,7 @@ are consumed by the current Ascend build path:
 - `--swift_branch` (default: `main`): selects the ms-swift source branch or tag and is included in the output image tag.
 - `--megatron_branch` (default: `v0.15.3`): selects the Megatron-LM source branch or tag.
 - `--mindspeed_branch` (default: `core_r0.15.3`): selects the MindSpeed source branch or tag.
+- `--mcore_bridge_branch` (default: `main`): selects the mcore-bridge source branch or release tag for the editable install.
 
 `--python_version` does not override the Python version for Ascend images;
 select it through `--base_image`. `--modelscope_branch` is accepted by the

--- a/docker/ascend/OVERVIEW.ascend.md
+++ b/docker/ascend/OVERVIEW.ascend.md
@@ -1,6 +1,6 @@
 # ms-swift Ascend
 
-> English | [中文](./OVERVIEW.ascend.zh.md)
+> English | [中文](https://github.com/modelscope/modelscope/blob/master/docker/ascend/OVERVIEW.ascend.zh.md)
 
 ms-swift Ascend images provide a ready-to-use ms-swift environment for Huawei Ascend Atlas NPUs. The images are built on top of the Ascend CANN container images and include the Python, CANN, TorchNPU, vLLM Ascend, FLA, Megatron, MindSpeed, mcore-bridge, ms-swift, and ModelScope runtime components needed for Ascend inference and training workflows.
 
@@ -43,7 +43,7 @@ The Ascend Dockerfile installs and configures:
 
 Images built by `docker/build_image.py --image_type ascend` use this tag format:
 
-The published-tag index is maintained in [`docker/ascend/supported_tags.md`](./supported_tags.md).
+The published-tag index is maintained in [`docker/ascend/supported_tags.md`](https://github.com/modelscope/modelscope/blob/master/docker/ascend/supported_tags.md).
 
 ```text
 ${DOCKER_REGISTRY}:<swift-branch>-<cann-version-tag>-torch_npu<TorchNPU-version>-<hardware-tag>-<os-tag>-<python-tag>-<arch>
@@ -73,10 +73,10 @@ The latest A2 and A3 images are hosted at [quay.io/ascend/ms-swift](https://quay
 
 **Device / CANN Base Image / OS / Image Tag / Dockerfile**
 
-- A3 — 9.1.0 — openEuler 24.03 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-a3-openeuler24.03-py3.12` — [Dockerfile.ascend](./Dockerfile.ascend)
-- A3 — 9.1.0 — Ubuntu 22.04 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.12` — [Dockerfile.ascend](./Dockerfile.ascend)
-- A2 — 9.1.0 — openEuler 24.03 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-910b-openeuler24.03-py3.12` — [Dockerfile.ascend](./Dockerfile.ascend)
-- A2 — 9.1.0 — Ubuntu 22.04 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.12` — [Dockerfile.ascend](./Dockerfile.ascend)
+- A3 — 9.1.0 — openEuler 24.03 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-a3-openeuler24.03-py3.12` — [Dockerfile.ascend](https://github.com/modelscope/modelscope/blob/master/docker/ascend/Dockerfile.ascend)
+- A3 — 9.1.0 — Ubuntu 22.04 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.12` — [Dockerfile.ascend](https://github.com/modelscope/modelscope/blob/master/docker/ascend/Dockerfile.ascend)
+- A2 — 9.1.0 — openEuler 24.03 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-910b-openeuler24.03-py3.12` — [Dockerfile.ascend](https://github.com/modelscope/modelscope/blob/master/docker/ascend/Dockerfile.ascend)
+- A2 — 9.1.0 — Ubuntu 22.04 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.12` — [Dockerfile.ascend](https://github.com/modelscope/modelscope/blob/master/docker/ascend/Dockerfile.ascend)
 
 ## Build Locally
 

--- a/docker/ascend/OVERVIEW.ascend.zh.md
+++ b/docker/ascend/OVERVIEW.ascend.zh.md
@@ -32,7 +32,7 @@ Ascend Dockerfile 会安装和配置：
 | FLA                       | 从 `fla-org/flash-linear-attention` 源码 checkout，默认 `main` 分支；可通过 `--fla_version` 指定分支或 release tag |
 | Megatron-LM               | 源码 checkout，默认分支 `v0.15.3`；可通过 `--megatron_branch` 配置 |
 | MindSpeed                 | 源码 checkout，默认分支 `core_r0.15.3`；可通过 `--mindspeed_branch` 配置 |
-| mcore-bridge              | PyPI 上的最新发布版；Ascend 构建入口没有独立的版本配置参数 |
+| mcore-bridge              | 从 `modelscope/mcore-bridge` 源码 checkout 并以 editable 模式安装，默认 `main` 分支；可通过 `--mcore_bridge_branch` 指定分支或 release tag |
 | ms-swift                  | 来自 `modelscope/ms-swift` 的源码 checkout，默认分支 `main`；可通过 `--swift_branch` 配置 |
 | DeepSpeed                 | 安装满足 `deepspeed>=0.19` 的最新发布包；`TORCH_DEVICE_BACKEND_AUTOLOAD=0` 仅作用于构建时的安装命令 |
 | ModelScope                | 通过 `pip install -U modelscope` 安装 PyPI 最新发布包；Ascend 镜像不再 clone ModelScope 或 modelscope-hub 源码仓库 |
@@ -110,7 +110,8 @@ python docker/build_image.py \
   --modelscope_branch master \
   --swift_branch v4.5.2 \
   --megatron_branch core_v0.16.0 \
-  --mindspeed_branch core_r0.16.0
+  --mindspeed_branch core_r0.16.0 \
+  --mcore_bridge_branch v1.6.2
 ```
 
 ## 自定义构建参数
@@ -137,6 +138,7 @@ python docker/build_image.py \
 - `--swift_branch`（默认：`main`）：选择 ms-swift 源码分支或 tag，并写入输出镜像 tag。
 - `--megatron_branch`（默认：`v0.15.3`）：选择 Megatron-LM 源码分支或 tag。
 - `--mindspeed_branch`（默认：`core_r0.15.3`）：选择 MindSpeed 源码分支或 tag。
+- `--mcore_bridge_branch`（默认：`main`）：选择 mcore-bridge 源码分支或 release tag，并以 editable 模式安装。
 
 Ascend 镜像的 Python 版本必须通过 `--base_image` 选择，`--python_version`
 不会覆盖它。`--modelscope_branch` 虽然会被共用参数解析器接受，但 Ascend

--- a/docker/ascend/OVERVIEW.ascend.zh.md
+++ b/docker/ascend/OVERVIEW.ascend.zh.md
@@ -1,6 +1,6 @@
 # ms-swift Ascend
 
-> [English](./OVERVIEW.ascend.md) | 中文
+> [English](https://github.com/modelscope/modelscope/blob/master/docker/ascend/OVERVIEW.ascend.md) | 中文
 
 ms-swift Ascend 镜像面向华为昇腾 Atlas NPU，提供可直接使用的 ms-swift 运行环境。镜像基于 Ascend CANN 容器镜像构建，包含 Ascend 推理和训练工作流所需的 Python、CANN、TorchNPU、vLLM Ascend、FLA、Megatron、MindSpeed、mcore-bridge、ms-swift 以及 ModelScope 运行组件。
 
@@ -43,7 +43,7 @@ Ascend Dockerfile 会安装和配置：
 
 通过 `docker/build_image.py --image_type ascend` 构建的镜像使用以下 tag 格式：
 
-已发布 tag 索引见 [`docker/ascend/supported_tags.md`](./supported_tags.md)。
+已发布 tag 索引见 [`docker/ascend/supported_tags.md`](https://github.com/modelscope/modelscope/blob/master/docker/ascend/supported_tags.md)。
 
 ```text
 ${DOCKER_REGISTRY}:<swift-branch>-<cann-version-tag>-torch_npu<TorchNPU-version>-<hardware-tag>-<os-tag>-<python-tag>-<arch>
@@ -73,10 +73,10 @@ ${DOCKER_REGISTRY}:main-cann9.0.0-torch_npu2.9.0.post2-910b-ubuntu22.04-py3.11-a
 
 **设备 / CANN 基础镜像 / OS / 镜像 Tag / Dockerfile**
 
-- A3 — 9.1.0 — openEuler 24.03 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-a3-openeuler24.03-py3.12` — [Dockerfile.ascend](./Dockerfile.ascend)
-- A3 — 9.1.0 — Ubuntu 22.04 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.12` — [Dockerfile.ascend](./Dockerfile.ascend)
-- A2 — 9.1.0 — openEuler 24.03 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-910b-openeuler24.03-py3.12` — [Dockerfile.ascend](./Dockerfile.ascend)
-- A2 — 9.1.0 — Ubuntu 22.04 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.12` — [Dockerfile.ascend](./Dockerfile.ascend)
+- A3 — 9.1.0 — openEuler 24.03 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-a3-openeuler24.03-py3.12` — [Dockerfile.ascend](https://github.com/modelscope/modelscope/blob/master/docker/ascend/Dockerfile.ascend)
+- A3 — 9.1.0 — Ubuntu 22.04 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.12` — [Dockerfile.ascend](https://github.com/modelscope/modelscope/blob/master/docker/ascend/Dockerfile.ascend)
+- A2 — 9.1.0 — openEuler 24.03 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-910b-openeuler24.03-py3.12` — [Dockerfile.ascend](https://github.com/modelscope/modelscope/blob/master/docker/ascend/Dockerfile.ascend)
+- A2 — 9.1.0 — Ubuntu 22.04 — `v4.5.2-cann9.1.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.12` — [Dockerfile.ascend](https://github.com/modelscope/modelscope/blob/master/docker/ascend/Dockerfile.ascend)
 
 ## 本地构建
 

--- a/docker/build_image.py
+++ b/docker/build_image.py
@@ -1043,6 +1043,8 @@ class AscendImageBuilder(StableGPUImageBuilder):
                                       self.args.megatron_branch)
             content = content.replace('{mindspeed_branch}',
                                       self.args.mindspeed_branch)
+            content = content.replace('{mcore_bridge_branch}',
+                                      self.args.mcore_bridge_branch)
         return content
 
     def image(self) -> str:
@@ -1094,6 +1096,7 @@ parser.add_argument('--modelscope_version', type=str, default='9.99.0')
 parser.add_argument('--swift_branch', type=str, default='main')
 parser.add_argument('--megatron_branch', type=str, default='v0.15.3')
 parser.add_argument('--mindspeed_branch', type=str, default='core_r0.15.3')
+parser.add_argument('--mcore_bridge_branch', type=str, default='main')
 parser.add_argument('--soc_version', type=str, default='ascend910_9391')
 parser.add_argument('--arch', type=str, choices=['x86', 'arm'], default=None)
 parser.add_argument(


### PR DESCRIPTION
## Summary

Allow Ascend image builds to select the `mcore-bridge` source branch or release tag instead of always installing the latest PyPI release. Also replace repository-relative links in both Ascend OVERVIEW documents with absolute GitHub URLs so they resolve when the documents are displayed outside GitHub.

## Changes

- Add `--mcore_bridge_branch` (default: `main`) to `docker/build_image.py` and pass it into the Ascend Dockerfile template.
- Clone `modelscope/mcore-bridge` at the selected branch or tag into `/mcore-bridge` and install it with `pip install --no-cache-dir -e .`.
- Update the English and Chinese Ascend documentation with the source installation behavior, the new parameter, and a `--mcore_bridge_branch v1.6.2` example.
- Point the language-switch, `supported_tags.md`, and `Dockerfile.ascend` links in both OVERVIEW documents to their corresponding files on GitHub `master`.

Selecting a release tag allows users to control the mcore-bridge revision; the default `main` branch remains a moving reference and does not guarantee reproducible image builds.

## Validation

- Reviewed the current PR diff across the Dockerfile, Python build entrypoint, and both OVERVIEW documents.
- Verified that the documentation link targets exist in the local checkout and that no relative Markdown links remain in either OVERVIEW.
- `git diff --check` passed for the documentation link changes.
- Full Docker image build and NPU runtime validation remain pending.
